### PR TITLE
Merge pull request #5 from ibm-hyperknowledge/dev

### DIFF
--- a/graphfactory.js
+++ b/graphfactory.js
@@ -89,6 +89,8 @@ function serializeGraph(aGraph, callback)
 		case "text/turtle":
 			n3Serialize(aGraph, callback);
 			break;
+		default:
+			callback(`The mimeType ${mimeType} is not currently supported for serialization.`);
 	}
 	return out;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rdf2hk",
-	"version": "1.1.4",
+	"version": "1.1.3",
 	"description": "This library converts RDF to Hyperknowledge Description",
 	"main": "index.js",
 	"author": "IBM Research",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rdf2hk",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"description": "This library converts RDF to Hyperknowledge Description",
 	"main": "index.js",
 	"author": "IBM Research",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rdf2hk",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "This library converts RDF to Hyperknowledge Description",
 	"main": "index.js",
 	"author": "IBM Research",

--- a/parser.js
+++ b/parser.js
@@ -234,8 +234,10 @@ function parseGraph(graph, options)
 		}
 		else if (convertOwl && owlParser.shouldConvert(s, p, o, parent))
 		{
-			owlParser.createRelationships(s, p, o, parent);
-			return;
+			if (owlParser.createRelationships(s, p, o, parent)) 
+			{
+				return;
+			}
 		}
 
 		// Set relationship

--- a/simpleowlparser.js
+++ b/simpleowlparser.js
@@ -72,8 +72,6 @@ class SimpleOwlParser
 				connector.addRole(this.subjectLabel, RoleTypes.SUBJECT);
 				connector.addRole(this.objectLabel, RoleTypes.OBJECT);
 
-				connector.setOrAppendToProperty(rdfs.TYPE_URI, o);
-
 				this.entities[s] = connector;
 			}
 		}
@@ -111,7 +109,10 @@ class SimpleOwlParser
 			{
 				ref.setOrAppendToProperty(p, o);
 			}
+
+			return true;
 		}
+		return false;
 
 	}
 


### PR DESCRIPTION
This pull request includes the following improvements:

- Retrieving error if mimeType is not supported for serialization. (This guarantees that the callback function is called if an unsupported  mimeType is passed as input)
- When using OWL import mode, create links between OWL Object Properties' connectors and owl:ObjectProperty node, via refnode, instead of creating a connector property with owl:ObjectProperty as a string. (This guarantees that the original RDF triples that represent this relationship will be preserved)