### PR TITLE
Merge pull request #6 from ibm-hyperknowledge/dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rdf2hk",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "This library converts RDF to Hyperknowledge Description",
 	"main": "index.js",
 	"author": "IBM Research",

--- a/parser.js
+++ b/parser.js
@@ -92,6 +92,7 @@ function parseGraph(graph, options)
 
 	const subjectLabel = options.subjectLabel || Constants.DEFAULT_SUBJECT_ROLE;
 	const objectLabel = options.objectLabel || Constants.DEFAULT_OBJECT_ROLE;
+	const hierarchyConnectorIDs = options.hierarchyConnectorIDs || [rdfs.TYPE_URI, rdfs.SUBCLASSOF_URI, rdfs.SUBPROPERTYOF_URI];
 
 	let entities = {};
 	let connectors = {};
@@ -143,7 +144,7 @@ function parseGraph(graph, options)
 		{
 			let connector = new Connector();
 			connector.id = Utils.getIdFromResource(p);
-			connector.className = p === rdfs.TYPE_URI ? ConnectorClass.HIERARCHY : ConnectorClass.FACTS;
+			connector.className = hierarchyConnectorIDs.includes(p) ? ConnectorClass.HIERARCHY : ConnectorClass.FACTS;
 			connector.addRole(subjectLabel, RoleTypes.SUBJECT);
 			connector.addRole(objectLabel, RoleTypes.OBJECT);
 			connectors[connector.id] = connector;


### PR DESCRIPTION
Making set of hierarchy connector ids configurable (via options) and expanding default set of hierarchy connectors to include rdfs:subClassOf and rdfs:subPropertyOf in addition to rdf:type.