### PR TITLE
Partial fix to issue affecting serialisation of properties in ref nodes.

### DIFF
--- a/serializer.js
+++ b/serializer.js
@@ -276,7 +276,7 @@ function _addLiteral(entity, graph, predicate, value, metaProperty, graphName)
     let literal = Utils.createLiteralObject(v, lang, type);
 
     if (entity.hasOwnProperty('type')){
-        if (entity.type === 'ref'){
+        if (entity.type === Reference.type){
             //we are dealing with a ref node, use reference for the triple 
             graph.add(entity.ref, predicate, literal, graphName);
         }        

--- a/serializer.js
+++ b/serializer.js
@@ -250,7 +250,7 @@ function serialize(entities, options = {}, graph = new TriGGraph())
     return graph;
 }
 
-function _addLiteral(id, graph, predicate, value, metaProperty, graphName)
+function _addLiteral(entity, graph, predicate, value, metaProperty, graphName)
 {
     let typeInfo = {};
 
@@ -275,13 +275,13 @@ function _addLiteral(id, graph, predicate, value, metaProperty, graphName)
     }
     let literal = Utils.createLiteralObject(v, lang, type);
 
-    if (id.hasOwnProperty('type')){
-        if (id.type === 'ref'){
+    if (entity.hasOwnProperty('type')){
+        if (entity.type === 'ref'){
             //we are dealing with a ref node, use reference for the triple 
-            graph.add(id.ref, predicate, literal, graphName);
+            graph.add(entity.ref, predicate, literal, graphName);
         }        
     }
-    graph.add(id.id, predicate, literal, graphName);
+    graph.add(entity.id, predicate, literal, graphName);
 
 }
 

--- a/serializer.js
+++ b/serializer.js
@@ -273,10 +273,16 @@ function _addLiteral(id, graph, predicate, value, metaProperty, graphName)
     {
         lang = typeInfo.lang;
     }
-    
     let literal = Utils.createLiteralObject(v, lang, type);
 
-    graph.add(id, predicate, literal, graphName);
+    if (id.hasOwnProperty('type')){
+        if (id.type === 'ref'){
+            //we are dealing with a ref node, use reference for the triple 
+            graph.add(id.ref, predicate, literal, graphName);
+        }        
+    }
+    graph.add(id.id, predicate, literal, graphName);
+
 }
 
 function _collectProperties(entity, graph, options)
@@ -302,7 +308,7 @@ function _collectProperties(entity, graph, options)
 			if(metaProperty !== null)
 			{
 				// Update only metaproperty
-				_addLiteral(entity.id, graph, key, null, metaProperty, graphName);
+				_addLiteral(entity, graph, key, null, metaProperty, graphName);
 			}
 			return;
 		}
@@ -327,12 +333,12 @@ function _collectProperties(entity, graph, options)
             {
                 if(metaProperty)
                 {
-                    _addLiteral(entity.id, graph, key, value[i], metaProperty, graphName);
+                    _addLiteral(entity, graph, key, value[i], metaProperty, graphName);
                 }
                 else
                 {
                     let currentMetaProperty = Utils.getTypeIfNumberOrBoolean(value[i]);
-                    _addLiteral(entity.id, graph, key, value[i], currentMetaProperty, graphName);
+                    _addLiteral(entity, graph, key, value[i], currentMetaProperty, graphName);
                 }
             }
         }
@@ -342,7 +348,7 @@ function _collectProperties(entity, graph, options)
             {
                 metaProperty = Utils.getTypeIfNumberOrBoolean(value);
             }
-            _addLiteral(entity.id, graph, key, value, metaProperty, graphName);
+            _addLiteral(entity, graph, key, value, metaProperty, graphName);
         }
     });
 }


### PR DESCRIPTION
There seems to be a bug in the rdk to hk conversion. When we save a link associating two reference nodes in a HKB with Jena backend, it creates a triple representing the link between the two **dereferenced** nodes, as well as the usual triples representing details about the link in HK. This facilitates querying the model with SPARQL. However, the same conversion rule is not being applied to properties in ref nodes. We would expect that such properties would also be added as triples between the dereferenced node and the literals. This is a partial, barely tested patch which seems to work in some cases (KES, for instance). 
