### PR TITLE
Merge pull request #10 from ibm-hyperknowledge/dev 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rdf2hk",
-	"version": "1.1.6",
+	"version": "1.1.7",
 	"description": "This library converts RDF to Hyperknowledge Description",
 	"main": "index.js",
 	"author": "IBM Research",


### PR DESCRIPTION
Refactoring getEntityTitle to consider language preference for entities with multiple titles.