### PR TITLE
Refactoring OWL Time conversion:

### DIFF
--- a/hkserializer.js
+++ b/hkserializer.js
@@ -262,7 +262,7 @@ function _serializeAnchors(uri, entity, parentUri, graph)
 					{
                         if(this.reifyAnchorProperties && this.owlTimeSerializer)
                         {
-                            this.owlTimeSerializer.serializeTemporalAnchorProperty(interfaceNode, p, prop, parentUri);
+                            this.owlTimeSerializer.serializeTemporalAnchorProperty(interfaceNode, p, prop, parentUri, properties);
                         }
                         else
                         {

--- a/owltime.js
+++ b/owltime.js
@@ -5,13 +5,18 @@
 "use strict";
 
 const INSTANT_URI = "<http://www.w3.org/2006/time#Instant>";
+const INTERVAL_URI = "<http://www.w3.org/2006/time#Interval>";
 const PROPER_INTERVAL_URI = "<http://www.w3.org/2006/time#ProperInterval>";
+const DATE_TIME_INTERVAL = "<http://www.w3.org/2006/time#DateTimeInterval>";
 const HAS_BEGINNING_URI = "<http://www.w3.org/2006/time#hasBeginning>";
 const HAS_END_URI = "<http://www.w3.org/2006/time#hasEnd>";
 const DATE_TIME_URI = "<http://www.w3.org/2006/time#inXSDDateTime>";
 
 exports.INSTANT_URI = INSTANT_URI;
+exports.INTERVAL_URI = INTERVAL_URI;
 exports.PROPER_INTERVAL_URI = PROPER_INTERVAL_URI;
+exports.DATE_TIME_INTERVAL = DATE_TIME_INTERVAL;
+exports.INTERVAL_URIS = [INTERVAL_URI, PROPER_INTERVAL_URI, DATE_TIME_INTERVAL];
 exports.HAS_BEGINNING_URI = HAS_BEGINNING_URI;
 exports.HAS_END_URI = HAS_END_URI;
 exports.DATE_TIME_URI = DATE_TIME_URI;

--- a/owltimeserializer.js
+++ b/owltimeserializer.js
@@ -4,19 +4,72 @@
  */
 "use strict";
 
-const INSTANT_URI = "<http://www.w3.org/2006/time#Instant>";
-const INTERVAL_URI = "<http://www.w3.org/2006/time#Interval>";
-const PROPER_INTERVAL_URI = "<http://www.w3.org/2006/time#ProperInterval>";
-const DATE_TIME_INTERVAL = "<http://www.w3.org/2006/time#DateTimeInterval>";
-const HAS_BEGINNING_URI = "<http://www.w3.org/2006/time#hasBeginning>";
-const HAS_END_URI = "<http://www.w3.org/2006/time#hasEnd>";
-const DATE_TIME_URI = "<http://www.w3.org/2006/time#inXSDDateTime>";
+const rdf               = require("./rdf");
+const xml               = require("./xmlschema");
+const owltime           = require("./owltime");
+const Utils             = require("./utils");
+const { type } = require("hklib/context");
 
-exports.INSTANT_URI = INSTANT_URI;
-exports.INTERVAL_URI = INTERVAL_URI;
-exports.PROPER_INTERVAL_URI = PROPER_INTERVAL_URI;
-exports.DATE_TIME_INTERVAL = DATE_TIME_INTERVAL;
-exports.INTERVAL_URIS = [INTERVAL_URI, PROPER_INTERVAL_URI, DATE_TIME_INTERVAL];
-exports.HAS_BEGINNING_URI = HAS_BEGINNING_URI;
-exports.HAS_END_URI = HAS_END_URI;
-exports.DATE_TIME_URI = DATE_TIME_URI;
+class OwlTimeSerializer
+{
+	constructor (sharedGraph, options)
+	{
+        this.graph = sharedGraph;
+        this.timeContext = options.timeContext;
+	}
+
+	serializeTemporalAnchorBind (entity, entities, subjectLabel, objectLabel, subjId, objId, defaultGraph, context)
+	{
+        if(this.timeContext === subjId && subjId === objId)
+        {
+            // serialize triple using timeContext anchors
+            subjId = entity.binds[subjectLabel][subjId][0];
+            objId = entity.binds[objectLabel][objId][0];
+            context = (entities.hasOwnProperty(entity.parent) ? entities[entity.parent].parent : defaultGraph) || defaultGraph;
+            this.graph.add(subjId, entity.connector, objId, context);
+        }
+        else
+        {
+            this.graph.add(subjId, entity.connector, objId, context);
+        }
+    }
+    
+    serializeTemporalAnchorProperty(interfaceNode, p, prop, parentUri, interfaceProperties)
+    {
+        const hasTypeArray = interfaceProperties.hasOwnProperty(rdf.TYPE_URI) && Array.isArray(interfaceProperties[rdf.TYPE_URI]);
+        const typeArray = hasTypeArray ? interfaceProperties[rdf.TYPE_URI] : [];
+        
+        const isInstant = typeArray.includes(owltime.INSTANT_URI);
+        let isInterval = false;
+        owltime.INTERVAL_URIS.forEach((uri) => isInterval = isInterval || interfaceProperties[rdf.TYPE_URI].includes(uri));
+        
+        if(p === rdf.TYPE_URI && Array.isArray(prop))
+        {
+            for(let i = 0; i < prop.length; i++)
+            {
+                this.graph.add(interfaceNode, p, prop[i], parentUri);
+            }
+        }
+        else if((p === 'begin' || p === 'end') && (isInstant || isInterval))
+        {
+            if(isInstant)
+            {
+                this.graph.add(interfaceNode, owltime.DATE_TIME_URI, Utils.createLiteralObject(prop, null, xml.DATETIME_URI), parentUri);
+            }
+            this.graph.add(interfaceNode, p, Utils.createLiteralObject(prop), parentUri);
+        }
+        else if(p === owltime.HAS_BEGINNING_URI || owltime.HAS_END_URI)
+        {
+            this.graph.add(interfaceNode, p, prop, parentUri);    
+        }
+        else
+        {
+            this.graph.add(interfaceNode, p, Utils.createLiteralObject(prop), parentUri);
+        }
+    }
+
+
+
+}
+
+module.exports = OwlTimeSerializer;

--- a/owltimeserializer.js
+++ b/owltimeserializer.js
@@ -4,58 +4,19 @@
  */
 "use strict";
 
-const rdf               = require("./rdf");
-const xml               = require("./xmlschema");
-const owltime           = require("./owltime");
-const Utils             = require("./utils");
+const INSTANT_URI = "<http://www.w3.org/2006/time#Instant>";
+const INTERVAL_URI = "<http://www.w3.org/2006/time#Interval>";
+const PROPER_INTERVAL_URI = "<http://www.w3.org/2006/time#ProperInterval>";
+const DATE_TIME_INTERVAL = "<http://www.w3.org/2006/time#DateTimeInterval>";
+const HAS_BEGINNING_URI = "<http://www.w3.org/2006/time#hasBeginning>";
+const HAS_END_URI = "<http://www.w3.org/2006/time#hasEnd>";
+const DATE_TIME_URI = "<http://www.w3.org/2006/time#inXSDDateTime>";
 
-class OwlTimeSerializer
-{
-	constructor (sharedGraph, options)
-	{
-        this.graph = sharedGraph;
-        this.timeContext = options.timeContext;
-	}
-
-	serializeTemporalAnchorBind (entity, entities, subjectLabel, objectLabel, subjId, objId, defaultGraph, context)
-	{
-        if(this.timeContext === subjId && subjId === objId)
-        {
-            // serialize triple using timeContext anchors
-            subjId = entity.binds[subjectLabel][subjId][0];
-            objId = entity.binds[objectLabel][objId][0];
-            context = (entities.hasOwnProperty(entity.parent) ? entities[entity.parent].parent : defaultGraph) || defaultGraph;
-            this.graph.add(subjId, entity.connector, objId, context);
-        }
-        else
-        {
-            this.graph.add(subjId, entity.connector, objId, context);
-        }
-    }
-    
-    serializeTemporalAnchorProperty(interfaceNode, p, prop, parentUri)
-    {
-        if(p === rdf.TYPE_URI && Array.isArray(prop))
-        {
-            for(let i = 0; i < prop.length; i++)
-            {
-                this.graph.add(interfaceNode, p, prop[i], parentUri);
-            }
-            return;
-        }
-        else if(p === 'begin')
-        {
-            this.graph.add(interfaceNode, owltime.DATE_TIME_URI, Utils.createLiteralObject(prop, null, xml.DATETIME_URI), parentUri);
-        }
-        else if(p === 'end')
-        {
-            this.graph.add(interfaceNode, owltime.DATE_TIME_URI, Utils.createLiteralObject(prop, null, xml.DATETIME_URI), parentUri);
-        }
-        this.graph.add(interfaceNode, p, Utils.createLiteralObject(prop), parentUri);
-    }
-
-
-
-}
-
-module.exports = OwlTimeSerializer;
+exports.INSTANT_URI = INSTANT_URI;
+exports.INTERVAL_URI = INTERVAL_URI;
+exports.PROPER_INTERVAL_URI = PROPER_INTERVAL_URI;
+exports.DATE_TIME_INTERVAL = DATE_TIME_INTERVAL;
+exports.INTERVAL_URIS = [INTERVAL_URI, PROPER_INTERVAL_URI, DATE_TIME_INTERVAL];
+exports.HAS_BEGINNING_URI = HAS_BEGINNING_URI;
+exports.HAS_END_URI = HAS_END_URI;
+exports.DATE_TIME_URI = DATE_TIME_URI;

--- a/owltimeserializer.js
+++ b/owltimeserializer.js
@@ -8,7 +8,6 @@ const rdf               = require("./rdf");
 const xml               = require("./xmlschema");
 const owltime           = require("./owltime");
 const Utils             = require("./utils");
-const { type } = require("hklib/context");
 
 class OwlTimeSerializer
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rdf2hk",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "This library converts RDF to Hyperknowledge Description",
 	"main": "index.js",
 	"author": "IBM Research",


### PR DESCRIPTION
- Suppress hasBeginning/hasEnd links when applying OWLTime conversion; 
- Propagate instant begin/end to associated intervals;
- Use the instant ID/URI as begin/end in the case of indefinite instants;
- Convert interval, proper interval and date time interval similarly.