### PR TITLE
Adding sparql builder, factory and helper, and update helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"punycode": "^2.1.1",
 		"rdfxml-streaming-parser": "^1.3.2",
 		"uuid": "^3.1.0",
-		"@rdfjs/data-model": "^1.1.2"
+		"@rdfjs/data-model": "^1.1.2",
+		"sparqljs": "^3.2.0"
 	}
 }

--- a/sparqlbuilder.js
+++ b/sparqlbuilder.js
@@ -1,0 +1,347 @@
+/*
+ * copyright: IBM Confidential
+ * copyright: OCO Source Materials
+ * copyright: © IBM Corp. All Rights Reserved
+ * date: 2020
+ *
+ * IBM Certificate of Originality
+ */
+"use strict";
+
+const Utils             = require("./utils");
+const Constants         = require("./constants");
+
+function SparqlBuilder()
+{
+	this.query = "";
+
+	this.identation = "";
+}
+
+
+SparqlBuilder.prototype.construct = function(input = null)
+{
+	if(!input)
+	{
+		this.query += " CONSTRUCT { GRAPH ?g { ?s ?p ?o } . GRAPH ?g { ?a ?b ?c } }" // default construct
+		return;
+	}
+
+	this.query  += "CONSTRUCT \n{\n"
+
+	this.addIdentation();
+
+	let chunk = "";
+	if(typeof input === "function")
+	{
+		input();
+	}
+	else if(typeof input === "string")
+	{
+		this.query += this.identation + input;
+	}
+	else if(Array.isArray(input))
+	{
+		for(let i = 0; i < input.length; i++)
+		{
+			let v = input[i];
+			chunk += this.identation + `GRAPH ?${v[3] } { ?${v[0]} ?${v[1]} ?${v[2]} } . `
+		}
+	}
+
+	this.subIdentation();
+
+	chunk += "\n}\n";
+
+	// return chunk;
+	this.query += chunk;
+
+}
+
+SparqlBuilder.prototype.select = function(variables = null, isDistinct = false)
+{
+	if(!variables)
+	{
+		this.query += ` SELECT ${isDistinct ? "DISTINCT " : ""} ?s ?p ?o ?g`;
+		return;
+	}
+
+	let chunk = `SELECT ${isDistinct ? "DISTINCT " : ""}`;
+
+	for(let i = 0; i < variables.length; i++)
+	{
+		let v = variables[i];
+		chunk += v.startsWith("?") ? `${v} ` : `?${v} `;
+	}
+
+	this.query += chunk;
+}
+
+SparqlBuilder.prototype.describe = function(variables = null)
+{
+	let chunk = "DESCRIBE ";
+	if(variables)
+	{
+		for(let i = 0; i < variables.length; i++)
+		{
+			let v = variables[i];
+			chunk += v.startsWith("?") ? `${v} ` : `?${v} `;
+		}
+	}
+	else
+	{
+		chunk+= "?s";
+	}
+
+	this.query += chunk;
+}
+
+SparqlBuilder.prototype.delete = function(input = null)
+{
+	this.query += "DELETE ";
+
+	if(typeof input === "function")
+	{
+		this.closure(input);
+	}
+	else if(Array.isArray(input))
+	{
+		this.query += _createPattern(input);
+	}
+	else
+	{
+		this.append(input, true);
+	}
+}
+
+SparqlBuilder.prototype.insertData = function(input = null)
+{
+	this.query += "INSERT DATA ";
+
+	if(typeof input === "function")
+	{
+		this.closure(input);
+	}
+	else if(Array.isArray(input))
+	{
+		this.query += _createPattern(input);
+	}
+	else
+	{
+		this.append(input, true);
+	}
+}
+
+SparqlBuilder.prototype.insert = function(input = null)
+{
+	this.query += "INSERT ";
+
+	if(typeof input === "function")
+	{
+		this.closure(input);
+	}
+	else if(Array.isArray(input))
+	{
+		this.query += _createPattern(input);
+	}
+	else
+	{
+		this.append(input, true);
+	}
+}
+
+SparqlBuilder.prototype.where = function(callback)
+{
+	this.query += this.identation + "\nWHERE {\n";
+
+	this.addIdentation();
+	callback();
+	this.subIdentation();
+
+	this.query += "\n}\n";
+}
+
+SparqlBuilder.prototype.addIdentation = function()
+{
+	this.identation += " ";
+}
+
+SparqlBuilder.prototype.subIdentation = function()
+{
+	this.identation = this.identation.substr(0, this.identation.length-1);
+}
+
+SparqlBuilder.prototype.appendComment = function(comment)
+{
+	this.append(`# ${comment}`);
+}
+
+SparqlBuilder.prototype.addNewLine = function(comment)
+{
+	this.query += "\n";
+}
+
+SparqlBuilder.prototype.closure = function(callback)
+{
+	this.query += `\n${this.identation}{\n`;
+
+	this.addIdentation();
+
+	callback();
+
+	this.subIdentation();
+
+	this.query += `\n${this.identation}}\n`;
+
+}
+
+SparqlBuilder.prototype.addValues = function(variable, values, isUri = true)
+{
+	let chunk = `VALUES ${variable.startsWith("?") ? variable: `?${variable}`} {`;
+
+	for(let i = 0;	i < values.length; i++)
+	{
+		if(isUri)
+		{
+			chunk += `${_convertToUri(values[i])} `;
+		}
+		else
+		{
+			chunk += `"${values[i]}"`;
+		}
+	}
+	chunk += "} . ";
+
+	this.append(chunk);
+
+	// this.query += chunk;
+}
+
+SparqlBuilder.prototype.getQuery = function()
+{
+	return this.query;
+}
+
+SparqlBuilder.prototype.appendUnion = function()
+{
+	this.query += this.identation +  "UNION";
+}
+
+SparqlBuilder.prototype.append = function(chunk, enclosured = false)
+{
+	if(!chunk)
+	{
+		throw Error("Invalid filter.");
+	}
+	if(enclosured)
+	{
+		this.query += this.identation + `{ ${chunk} }\n`;
+	}
+	else
+	{
+		this.query += this.identation + `${chunk} \n`;
+	}
+}
+
+SparqlBuilder.prototype.optional = function(chunk)
+{
+	if(typeof chunk === "string")
+	{
+		this.query += this.identation +  `OPTIONAL { ${chunk} } \n`;
+	}
+	else if(typeof chunk === "function" )
+	{
+		this.query += this.identation +  "OPTIONAL { "
+		chunk();
+		this.query += "} ";
+	}
+}
+
+SparqlBuilder.prototype.bindVar = function(value, variable, enclosured = false)
+{
+	if(enclosured)
+	{
+		this.query += this.identation +  "{"
+		this.addIdentation();
+	}
+
+	if(!variable.startsWith("?"))
+	{
+		variable = "?" + variable;
+	}
+
+	if(value.startsWith("?"))
+	{
+		this.query += this.identation + `BIND (${value} AS ${variable}) . `;
+	}
+	else if(!Utils.isUri(value))
+	{
+		if(Utils.isLiteral(value))
+		{
+			this.query += this.identation + `BIND (${value} AS ${variable}) . `;
+		}
+		else
+		{
+			this.query += this.identation + `BIND ("${value}" AS ${variable}) . `;
+		}
+	}
+	else
+	{
+		this.query += this.identation + `BIND (${_convertToUri(value)} AS ${variable}) . `;
+	}
+	if(enclosured)
+	{
+		this.query += this.identation + "} \n"
+		this.subIdentation();
+	}
+	else
+	{
+		this.query += "\n"
+	}
+}
+
+SparqlBuilder.prototype.filter = function(value)
+{
+	this.append(` FILTER (${value}) . `);
+}
+
+function _createPattern(variables)
+{
+
+	let chunk = "";
+	if(variables)
+	{
+		for(let i = 0; i < variables.length; i++)
+		{
+			let v = variables[i];
+			chunk += `GRAPH ${v[3]} { ${v[0]} ${v[1]} ${v[2]} } . `
+		}
+	}
+	else
+	{
+		chunk = " GRAPH ?g { ?s ?p ?o } . GRAPH ?g { ?o ?a ?b } "
+	}
+	return chunk;
+}
+
+function _convertToUri(id)
+{
+	if(!id)
+	{
+		return `<${Constants.HK_NULL}>`;
+	}
+	else if(Utils.isUri(id))
+	{
+		return id;
+	}
+	else if(Utils.isBlankNode(id))
+	{
+		return Utils.createBlankNodeUri(id.substr(2));
+	}
+	else
+	{
+		return `<${Utils.generateResourceFromId(id)}>`;
+	}
+}
+
+module.exports = SparqlBuilder;

--- a/sparqlfactory.js
+++ b/sparqlfactory.js
@@ -1,0 +1,1259 @@
+/*
+ * copyright: IBM Confidential
+ * copyright: OCO Source Materials
+ * copyright: © IBM Corp. All Rights Reserved
+ * date: 2020
+ *
+ * IBM Certificate of Originality
+ */
+"use strict";
+
+const Utils             = require("./utils");
+const Constants         = require("./constants");
+const HKUris           = require("./hk");
+const HKSerializer     = require("./hkserializer");
+
+const HKTypes          = require("hklib").Types;
+
+const SparqlBuilder    = require("./sparqlbuilder");
+
+const ENTITY_ANCHORS        = ` ?s ${HKUris.HAS_ANCHOR_URI} ?a . GRAPH ?g {?a ?b ?c} `;
+const REFERENCES_FILTERS    = ` ?g = ?g1 || !bound(?g1) `;
+
+const DEFAULT_GRAPH_PATTERN = `GRAPH ?g { ?s ?p ?o } .`;
+
+const FILTER_HK = `FILTER ( ?p != ${HKUris.ISA_URI} &&
+     ?p != ${HKUris.USES_CONNECTOR_URI} &&
+     ?p != ${HKUris.CLASSNAME_URI} &&
+     ?p != ${HKUris.REFERENCES_URI} &&
+     ?p != ${HKUris.HAS_PARENT_URI} &&
+     !STRSTARTS(STR(?p), "hkrole") &&
+     ( isIRI(?o) || isBlank(?o) ||  datatype(?o) != ${HKUris.DATA_LIST_URI}))`
+
+const HKTypeUriMap = {};
+HKTypeUriMap[HKTypes.NODE] = HKUris.NODE_URI;
+HKTypeUriMap[HKTypes.CONNECTOR] = HKUris.CONNECTOR_URI;
+HKTypeUriMap[HKTypes.LINK] = HKUris.LINK_URI;
+HKTypeUriMap[HKTypes.CONTEXT] = HKUris.CONTEXT_URI;
+HKTypeUriMap[HKTypes.REFERENCE] = HKUris.REF_URI;
+HKTypeUriMap[HKTypes.TRAIL] = HKUris.TRAIL_URI;
+
+function getAllEntitiesUncompressed ()
+{
+	let query= `SELECT ?s ?p ?o ?g
+				where
+				{
+					{ GRAPH ?g { ?s ?p ?o . }  } .
+					?s ?hk ?x.
+					values ?hk
+					{
+						${HKUris.ISA_URI}
+						${HKUris.BOUND_COMPONENT_URI}
+					}
+				}
+	`;
+	// console.log(query);
+	return query;
+}
+
+function getAllEntities (sparqlType = "construct")
+{
+	let builder = new SparqlBuilder();
+
+	if(sparqlType === "describe")
+	{
+		return "describe ?s ?o where {?s ?p ?o}"
+	}
+	builder.construct();
+
+	builder.where(() =>
+	{
+
+		builder.closure(() =>
+		{
+			builder.append("?s ?hk ?x .");
+			builder.addValues("?hk", [HKUris.ISA_URI, HKUris.USES_CONNECTOR_URI]);
+			builder.append(DEFAULT_GRAPH_PATTERN);
+		});
+
+		builder.appendUnion();
+
+		builder.closure(() =>
+		{
+			// builder.append(DEFAULT_GRAPH_PATTERN);
+			builder.addValues("?hk", [HKUris.ISA_URI, HKUris.USES_CONNECTOR_URI]);
+			builder.append("?s ?hk ?x .");
+			builder.append(ENTITY_ANCHORS);
+		});
+
+		builder.filter(REFERENCES_FILTERS);
+
+	});
+
+	let sparql = builder.getQuery();
+
+
+	return sparql;
+}
+
+function getAllEntitiesLazy (sparqlType = "construct")
+{
+	let builder = new SparqlBuilder();
+
+	builder[sparqlType]();
+
+	builder.where(() =>
+	{
+
+		builder.closure(() =>
+		{
+			builder.append("?s ?hk ?x .");
+			builder.addValues("?hk", [HKUris.ISA_URI, HKUris.USES_CONNECTOR_URI]);
+		});
+
+	});
+
+	let sparql = builder.getQuery();
+
+
+	return sparql;
+}
+
+function getEntities (ids)
+{
+	if(!ids)
+	{
+		throw "Ids can not be null";
+	}
+
+	let builder = new SparqlBuilder();
+
+	builder.construct();
+
+	builder.where(() =>
+	{
+		builder.closure(() =>
+		{
+			builder.addValues("?s", ids);
+			builder.append("GRAPH ?g { ?s ?p ?o	 } .");
+		})
+
+		builder.appendUnion();
+
+		builder.closure(() =>
+		{
+			builder.addValues("?s", ids);
+			builder.append(ENTITY_ANCHORS);
+		});
+
+		builder.filter(REFERENCES_FILTERS);
+	});
+
+	let sparql = builder.getQuery();
+
+	return sparql;
+}
+
+function filterEntities (filters)
+{
+	if(!filters)
+	{
+		throw "Filters can not be null";
+	}
+
+	let builder = new SparqlBuilder();
+
+	builder.construct(" GRAPH ?g { ?s ?p ?o } . GRAPH ?g { ?a ?b ?c } . GRAPH ?g1 {?a1 ?b1 ?c1} ");
+
+	builder.where(() =>
+	{
+		for(let i = 0; i < filters.length; i++)
+		{
+			let andFilters = filters[i];
+
+			let hasNode = _checkIfHasNodeInConstraint(andFilters);
+
+			if(i > 0)
+			{
+				builder.appendUnion();
+			}
+
+			builder.closure(() =>
+			{
+				builder.closure(() =>
+				{
+					appendUnionFilters(builder, andFilters);	
+					builder.append(" GRAPH ?g {?s ?p ?o} .");	
+				});
+
+				if(hasNode)
+				{
+					builder.appendUnion();
+
+					builder.closure(() =>
+					{
+						appendUnionFilters(builder, andFilters);	
+						builder.append(`?s ${HKUris.HAS_ANCHOR_URI} ?a . GRAPH ?g {?a ?b ?c}`, true);
+					});
+					
+					builder.appendUnion();
+
+					builder.closure(() =>
+					{
+						appendUnionFilters(builder, andFilters);	
+					});
+				}
+
+
+			})
+		}
+	});
+
+	let query = builder.getQuery();
+
+	return query;
+}
+
+function filterEntitiesLazy (filters, sparqlType = "construct")
+{
+	if(!filters)
+	{
+		throw "Filters can not be null";
+	}
+
+	let builder = new SparqlBuilder();
+
+	switch(sparqlType)
+	{
+		case "describe":
+			builder.describe();
+			break;
+		default :
+			builder.construct("GRAPH ?g { ?s ?hk ?x }");
+			break;
+	}
+
+	builder.where(() =>
+	{
+		for(let i = 0; i < filters.length; i++)
+		{
+			let andFilters = filters[i];
+
+			if(i > 0)
+			{
+				builder.appendUnion();
+			}
+
+			builder.closure(() =>
+			{
+				builder.closure(() =>
+				{
+					appendUnionFilters(builder, andFilters);	
+					builder.append("GRAPH ?g { ?s ?hk ?x . }");
+					builder.addValues("?hk", [HKUris.ISA_URI, HKUris.USES_CONNECTOR_URI]);
+				});
+			})
+		}
+	});
+
+	let query = builder.getQuery();
+
+	return query;
+}
+
+function filterEntitiesSelect (filters)
+{
+	if(!filters)
+	{
+		throw "Filters can not be null";
+	}
+
+	let builder = new SparqlBuilder();
+
+	builder.select(null, true);
+
+	builder.where(() =>
+	{
+		for(let i = 0; i < filters.length; i++)
+		{
+			let andFilters = filters[i];
+
+			let hasNode = _checkIfHasNodeInConstraint(andFilters);
+
+			if(i > 0)
+			{
+				builder.appendUnion();
+			}
+
+			builder.closure(() =>
+			{
+				builder.closure(() =>
+				{
+					appendUnionFilters(builder, andFilters);	
+					builder.append(" GRAPH ?g {?s ?p ?o} .");	
+				});
+
+				if(hasNode)
+				{
+					builder.appendUnion();
+
+					builder.closure(() =>
+					{
+						appendUnionFilters(builder, andFilters, "n");	
+						builder.append(`?n ${HKUris.HAS_ANCHOR_URI} ?s .`);
+						builder.append("GRAPH ?g { ?s ?p ?o } .");	
+					});
+					
+				}
+			});
+		}
+	});
+
+	let query = builder.getQuery();
+
+	return query;
+}
+
+function fromUris (uris, className, level, full)
+{
+	if(!uris)
+	{
+		throw "Uri can not be null";
+	}
+
+	if(uris.constructor !== Array)
+	{
+		uris = [uris];
+	}
+
+	let sparql = "";
+
+	if(level === undefined || level === null)
+	{
+		level = 1;
+	}
+
+	if(level === 0)
+	{
+		sparql = "describe ?s where { ";
+	}
+	else
+	{
+		sparql = "describe ?s ?o where { ";
+	}
+	if(className)
+	{
+		sparql += ` ?s  ${RDFS_TYPE_URI}  ${className} . `;
+	}
+
+	sparql += "{values ?s {";
+
+	for(let i = 0;  i < uris.length; i++)
+	{
+		sparql += `${_convertToUri(uris[i])} `;
+	}
+
+	sparql += "}";
+	sparql += " . ?s ?p ?o }" ;
+
+	if(full)
+	{
+		sparql += "union {values ?o {";
+
+		for(let i = 0;  i < uris.length; i++)
+		{
+			sparql += `${_convertToUri(uris[i])} `;
+		}
+
+		sparql += "}";
+		sparql += " . ?s ?p ?o }" ;
+
+	}
+
+	sparql += "}";
+	
+	return sparql;
+}
+
+function getEntitiesFromUris(ids)
+{
+	let builder = new SparqlBuilder();
+
+	builder.select(null, true);
+
+	builder.where(() =>
+	{
+		builder.closure(() =>
+		{
+			builder.addValues("?s", ids);
+			builder.append("GRAPH ?g { ?s ?p ?o	 } .");
+		})
+
+		builder.appendUnion();
+
+		builder.closure(() =>
+		{
+			builder.addValues("?n", ids);
+			builder.append("?n <http://research.ibm.com/ontologies/graph#hasAnchor> ?s .");
+			builder.append("GRAPH ?g { ?s ?p ?o } .");
+		});
+
+	});
+
+	let sparql = builder.getQuery();
+
+	return sparql;
+
+}
+
+// This query update the delete and insert triples
+// to update entities properties.
+// There are some scenarios:
+// I. Update properties
+// II. Update parents
+// III. Update properties and parents
+//
+//
+function updateTriples (changedEntities, changedParents)
+{
+	let builder = new SparqlBuilder();
+
+	let changedEntitiesKeys = Object.keys(changedEntities);
+	let changedParentKeys = Object.keys(changedParents);
+
+	// If there a no changes, just go away
+	if(changedEntitiesKeys.length === 0 && changedParentKeys.length === 0)
+	{
+		return null;
+	}
+
+	if(changedEntitiesKeys.length > 0)
+	{
+		// Delete previous properties
+		builder.delete(() =>
+		{
+			// Delete old properties
+			builder.append(`GRAPH ?g {?s ?p ?o} .`);
+			builder.append(`GRAPH ?g {?a ?b ?c} .`);
+		});
+		// Here we have to collect all properties that should be removed
+		// and be replaced to the new ones
+		builder.where(() =>
+		{
+			let first = true;
+
+			for(let e in changedEntities)
+			{
+				let entityUpdates = changedEntities[e];
+
+				let properties = entityUpdates.properties;
+
+				let interfacesToRemove = entityUpdates.interfacesToRemove;
+
+				let interfaceProperties = entityUpdates.interfacesPropertites;
+
+				if(!first) 
+				{
+					if (properties.length > 0 || interfacesToRemove.length > 0 || Object.keys(interfaceProperties).length > 0) 
+					{
+						builder.appendUnion();
+						first = true;
+					} 
+					else 
+					{
+						console.log(`STRANGE ENTITY: ${JSON.stringify(entityUpdates)}`);
+					}
+				} 
+
+				// Remove properties to be updated
+				if(properties.length > 0)
+				{
+					first = false;
+					builder.closure(() =>
+					{
+						builder.bindVar(_convertToUri(e), "?s");
+						builder.addValues("?p", properties);
+						builder.append(`GRAPH ?g {?s ?p ?o}`);
+					});
+				}
+
+				// Remove interfaces to be deleted
+				if(interfacesToRemove.length > 0)
+				{
+					if(!first)
+					{
+						builder.appendUnion();
+					}
+					first = false;
+					builder.closure(() =>
+					{
+						builder.bindVar(_convertToUri(e), "?s");
+						builder.append(`GRAPH ?g {?s ?p ?o} .`); 
+						builder.append(`bind (?o as ?a)`); // Trick
+						builder.append(`GRAPH ?g {?a ?b ?c} .`);
+
+						builder.addValues("?x", interfacesToRemove, false);
+						builder.append(`?a ${HKUris.ANCHOR_KEY_URI} ?x .`);
+						builder.append(`?s ${HKUris.HAS_ANCHOR_URI} ?a .`);
+					});
+				}
+
+				// Remove interfaces properties to be updated
+				if(Object.keys(interfaceProperties).length > 0)
+				{
+					for(let k in interfaceProperties)
+					{
+						if(!first)
+						{
+							builder.appendUnion();
+						}
+						first = false;
+
+						let properties = interfaceProperties[k];
+						builder.closure(() =>
+						{
+							builder.bindVar(_convertToUri(e), "?s");
+							builder.append(`GRAPH ?g {?a ?b ?c} .`);
+
+							builder.addValues("?b", properties);
+							builder.bindVar(k, "?x");
+							builder.append(`?a ${HKUris.ANCHOR_KEY_URI} ?x .`);
+							builder.append(`?s ${HKUris.HAS_ANCHOR_URI} ?a .`);
+						});
+					}
+				}
+			}
+		});
+
+		builder.append(";");
+
+		// Add new properties
+		for(let e = 0; e < changedEntitiesKeys.length; e++)
+		{
+			let entityId = changedEntitiesKeys[e];
+			let entity = changedEntities[entityId];
+			let newTriples = entity.triples || [];
+
+			const hasChangedParent = changedParents.hasOwnProperty(entityId);
+
+
+			// If the entity did not changed its parent
+			// then add again getting its previous parent
+			if(hasChangedParent)
+			{
+				// The triple are plenty, just add them
+				builder.insertData(() =>
+				{
+					for(let i = 0; i < newTriples.length; i++)
+					{
+						let t = newTriples[i];
+
+						builder.append(`GRAPH ${t[3]} { ${t[0]} ${t[1]} ${t[2]} } . `);
+					}
+				});
+			}
+			else
+			{
+				builder.insert(() =>
+				{
+					for(let i = 0; i < newTriples.length; i++)
+					{
+						let t = newTriples[i];
+
+						builder.append(`GRAPH ?g { ${t[0]} ${t[1]} ${t[2]} } . `);
+					}
+				});
+				builder.where(() =>
+				{
+					builder.append(` bind(${_convertToUri(entityId)} as ?s) . `);
+					builder.addValues("?p", [HKUris.USES_CONNECTOR_URI, HKUris.ISA_URI]);
+					builder.append(`GRAPH ?g { ?s ?p ?o } . `);
+				});
+
+			}
+			builder.append(";");
+		}
+	}
+
+	// Move triples to new parent
+	if(changedParentKeys.length > 0)
+	{
+
+		// Add all the previous entities to the new parent
+		for(let i = 0; i < changedParentKeys.length; i++)
+		{
+			let id = changedParentKeys[i];
+			let entityUri = _convertToUri(id);
+			let parentUri = _convertToUri(changedParents[id]);
+
+			builder.delete(() =>
+			{
+				// Delete old properties
+				builder.append(`GRAPH ?g {?s ?p ?o} .`);
+				builder.append(`GRAPH ?gOld  { ?s ${HKUris.HAS_PARENT_URI} ?gOld. } `);
+			});
+
+			builder.insert(() =>
+			{
+				// Insert new properties
+				// builder.append(`GRAPH ?g {?s ?p ?o} .`);
+				builder.append(`GRAPH ${parentUri}  { ?s ?p ?o . } `);
+				builder.append(`GRAPH ${parentUri}  { ?s ${HKUris.HAS_PARENT_URI} ${parentUri}. } `);
+			});
+
+			builder.where(() =>
+			{
+				builder.append(` bind(${entityUri} as ?s) . `);
+				builder.addValues("?isa", [HKUris.ISA_URI, HKUris.USES_CONNECTOR_URI]);
+				builder.append(` ?s ?isa ?x . `);
+				builder.append(` GRAPH ?g { ?s ?p ?o } . `);
+				builder.filter(` ?p != ${HKUris.HAS_PARENT_URI}`);
+				builder.append(` OPTIONAL { GRAPH ?gOld { ?s ${HKUris.HAS_PARENT_URI} ?gOld } . }`);
+			});
+
+			builder.append(";");
+		}
+
+	}
+
+	let query = builder.getQuery();
+
+	return query;
+}
+
+function removeEntities (ids)
+{
+	if(!ids)
+	{
+		throw "Ids can not be null";
+	}
+
+	let builder = new SparqlBuilder();
+
+	builder.delete("GRAPH ?g {?s ?p ?o} . GRAPH ?g {?a ?b ?c} ");
+
+	builder.where(() =>
+	{
+		builder.closure(() =>
+		{
+			builder.addValues("?s", ids)
+			builder.append(ENTITY_ANCHORS);
+		});
+
+		builder.appendUnion();
+		
+		builder.closure(() =>
+		{
+			builder.addValues("?o", ids);
+			builder.append(DEFAULT_GRAPH_PATTERN);
+		});
+
+		builder.appendUnion();
+
+		builder.closure(() =>
+		{
+			builder.addValues("?s", ids)
+			builder.append(DEFAULT_GRAPH_PATTERN);
+			// builder.optional(ENTITY_ANCHORS);
+		});
+
+		
+	});
+
+	return builder.getQuery();
+}
+
+function removeAllEntities ()
+{
+	return "CLEAR ALL";
+}
+
+function getContextHierarchy (uris, targetTypes, sparqlType = "construct")
+{
+	if(!uris)
+	{
+		throw "Uri can not be null";
+	}
+
+	if(uris.constructor !== Array)
+	{
+		uris = [uris];
+	}
+
+	const targetTypesUris = [];
+	if(Array.isArray(targetTypes))
+	{
+		targetTypes.forEach((type) => {
+			if(HKTypeUriMap.hasOwnProperty(type))
+			{
+				targetTypesUris.push(HKTypeUriMap[type])
+			}
+		});
+	}
+
+	let builder = new SparqlBuilder();
+
+	switch(sparqlType)
+	{
+		case "describe":
+			builder.describe(["?s ?o"]);
+			break;
+		default :
+			builder.construct(() =>
+			{
+				builder.append("GRAPH ?g {?s ?p ?o}");
+			});
+			break;
+	}
+
+	builder.where( () =>
+	{
+		builder.addValues("?parent", uris);
+		builder.append(` ?s ${HKUris.HAS_PARENT_URI}* ?parent .`);
+		builder.append(" GRAPH ?g {?s ?p ?o} .");
+		if(targetTypesUris)
+		{
+			builder.append(` ?s ${HKUris.ISA_URI} ?type`);
+			builder.addValues("?type", targetTypesUris);
+		}
+	});
+
+	let query = builder.getQuery();
+
+	return query;
+}
+
+function getLinks (ids, sparqlType = "construct")
+{
+	if(!ids)
+	{
+		throw "Uri can not be null";
+	}
+
+	let builder = new SparqlBuilder();
+
+	builder[sparqlType]();
+
+	builder.where(() =>
+	{
+		builder.closure(() =>
+		{
+
+			builder.closure(() =>
+			{
+				builder.addValues("?s", ids);
+
+				// Get the connector itself
+				builder.append(`?s ${HKUris.USES_CONNECTOR_URI} ?x`);
+				builder.append(`GRAPH ?g {?s ?p ?o}`);
+
+			});
+
+			builder.appendUnion();
+			builder.closure(() =>
+			{
+				builder.addValues("?x", ids);
+				// Link with a bound entity
+				builder.append(`?s ${HKUris.USES_CONNECTOR_URI} ?connector . ?s ?role ?x `);
+				builder.append(`GRAPH ?g {?s ?p ?o}`);
+			});
+
+			builder.appendUnion();
+			builder.closure(() =>
+			{
+				builder.addValues("?x", ids);
+				// Link with a bound entity
+				builder.append(`?s ${HKUris.ISA_URI} ${HKUris.CONNECTOR_URI} .`);
+				builder.append(`?link ?role ?x . ?link ${HKUris.USES_CONNECTOR_URI} ?s . `);
+				builder.append(`GRAPH ?g {?s ?p ?o}`);
+			});
+
+			// builder.appendUnion();
+
+			// builder.closure(() =>
+			// {
+			// 	builder.addValues("?x", ids);
+				
+			// 	// Connector from a bound entity
+			// 	// builder.append(`?s ${HKUris.ISA_URI} ${HKUris.CONNECTOR_URI} .`);
+			// 	// builder.append(`?link ${HKUris.USES_CONNECTOR_URI} ?s . `);
+			// 	builder.append(`?link ?role ?x `);
+			// })
+
+
+
+		});
+
+		builder.append(DEFAULT_GRAPH_PATTERN);
+	});
+
+	let sparql = builder.getQuery();
+
+	return sparql;
+}
+
+function deleteTriples (bgp)
+{
+	let builder = new SparqlBuilder();
+
+	builder.delete(() =>
+	{
+		builder.append("GRAPH ?g {?s ?p ?o}");
+	});
+
+	builder.where(() =>
+	{
+		builder.closure(() =>
+		{
+			if(bgp[0] !== null)
+			{
+				builder.bindVar(bgp[0], "s");
+			}
+			if(bgp[1] !== null)
+			{
+				builder.bindVar(bgp[1], "p");
+			}
+			if(bgp[2] !== null)
+			{
+				builder.bindVar(bgp[2], "o");
+			}
+			if(bgp[3] !== null)
+			{
+				builder.bindVar(bgp[3], "g");
+			}
+
+			builder.append("GRAPH ?g {?s ?p ?o}");
+		});
+
+		if(Utils.isUriOrBlankNode(bgp[0]) && !Utils.isUriOrBlankNode(bgp[2]))
+		{
+			builder.appendUnion();
+
+			builder.closure( () =>
+			{
+				builder.append(`?s ${HKUris.REFERENCES_URI} ${bgp[0]} `);
+				if(bgp[1] !== null)
+				{
+					builder.bindVar(bgp[1], "p");
+				}
+				if(bgp[2] !== null)
+				{
+					builder.bindVar(bgp[2], "o");
+				}
+				if(bgp[3] !== null)
+				{
+					builder.bindVar(bgp[3], "g");
+				}
+				builder.append("GRAPH ?g {?s ?p ?o}");
+			});
+		}
+	});
+
+	// console.log(builder.query);
+
+	return builder.query;
+}
+
+function getRdf(bgp, sparqlType = "construct")
+{
+	let builder = new SparqlBuilder();
+
+	switch(sparqlType)
+	{
+		case "select":
+			builder.select();
+			break;
+		default:
+			builder.construct(() =>
+			{
+				builder.append("GRAPH ?g {?s ?p ?o}");
+			});
+	}
+
+	builder.where(() =>
+	{
+		if(bgp[0] !== null)
+		{
+			builder.bindVar(bgp[0], "s");
+		}
+		if(bgp[1] !== null)
+		{
+			builder.bindVar(bgp[1], "p");
+		}
+		if(bgp[2] !== null)
+		{
+			builder.bindVar(bgp[2], "o");
+		}
+		if(bgp[3] !== null)
+		{
+			builder.bindVar(bgp[3], "g");
+		}
+
+		builder.append("GRAPH ?g {?s ?p ?o} .");
+
+		builder.append( FILTER_HK);
+
+	});
+
+	let out = builder.query;
+
+	return out;
+
+}
+
+function _filterForBinds(builder, binds, connector = null, parent = undefined)
+{
+
+	builder.closure(() =>
+	{
+		if(!connector)
+		{
+			builder.append(`?s ${HKUris.USES_CONNECTOR_URI} ?conn . `);
+		}
+		for(let role in binds)
+		{
+			if(Array.isArray(binds[role]))
+			{
+				builder.addValues("r", binds[role], true);
+
+				if(role === "*")
+				{
+					
+					builder.append(`?s ?anyRole ?r . `);
+				}
+				else
+				{
+					let uri = HKSerializer.compressRoleInUri(role);
+					// builder.append(`?s ${HKUris.USES_CONNECTOR_URI} ?conn . `);
+					builder.append(`?s ${uri} ?r . `);
+				}
+			}
+			else
+			{
+				if(role === "*")
+				{
+					// builder.append(`?s ${HKUris.USES_CONNECTOR_URI} ?conn . `);
+					builder.append(`?s ?anyRole ${_convertToUri(binds[role])} . `)
+				}
+				else
+				{
+					let uri = HKSerializer.compressRoleInUri(role);
+					// builder.append(`?s ${HKUris.USES_CONNECTOR_URI} ?conn . `);
+					builder.append(`?s ${uri} ${_convertToUri(binds[role])} . `)
+				}
+			}
+		}
+
+		if(connector)
+		{
+			builder.append(`GRAPH ?g {?s ?p ?o} .`)
+			// builder.append(`?s ${HKUris.USES_CONNECTOR_URI} ${_convertToUri(connector)} . `)
+			// builder.bindVar(_convertToUri(connector), "conn");
+			if(Array.isArray(connector))
+			{
+				builder.addValues("c", connector, true);
+				builder.append(`?s ${HKUris.USES_CONNECTOR_URI} ?c `);
+			}
+			else
+			{
+				// builder.append(`?s ${HKUris.USES_CONNECTOR_URI} ${_convertToUri(constraint[k])} .`, true);
+				builder.append(`?s ${HKUris.USES_CONNECTOR_URI} ${_convertToUri(connector)} . `)
+			}
+		}
+		if(parent !== undefined)
+		{
+			if(!connector)
+			{
+				builder.append(`GRAPH ?g {?s ?p ?o} .`)
+			}
+			_filterForParent(builder, parent);
+		}
+	});
+}
+
+function appendUnionFilters(builder, andFilters, idVar = "s")
+{
+	for(let j = 0; j < andFilters.length; j++)
+	{
+		let constraint = andFilters[j];
+
+		
+		if(Object.keys(constraint).length >= 2)
+		{
+			if(constraint.binds && constraint.connector)
+			{
+				_filterForBinds(builder, constraint.binds, constraint.connector, constraint.parent);
+				continue;
+			}
+		}
+
+		for(let k in constraint)
+		{
+			let constraintValue = constraint[k];
+
+
+			switch(k)
+			{
+				case "parent":
+				{
+					_filterForParent(builder, constraintValue);
+					break;
+				}
+				case "ref":
+				{
+					if(Array.isArray(constraintValue))
+					{
+						builder.addValues("r", constraintValue, true);
+						builder.append(`?s ${HKUris.REFERENCES_URI} ?r .`);
+					}
+					else if(constraint.parent)
+					{
+						builder.append('GRAPH ?g');
+						builder.closure(() => builder.append(`?s ${HKUris.REFERENCES_URI} ${_convertToUri(constraint[k])} .`));
+					}
+					else
+					{
+						builder.append(`?s ${HKUris.REFERENCES_URI} ${_convertToUri(constraint[k])} .`);
+					}
+					break;
+				}
+				case "type":
+				{
+					if(Array.isArray(constraintValue))
+					{
+						builder.append(_filterForTypeArray(constraintValue, idVar), true);	
+					}
+					else
+					{
+						builder.append(_filterForType(constraintValue, idVar), true);
+					}
+					break;
+				}
+				case "id":
+				{
+					if(Array.isArray(constraintValue))
+					{
+						builder.addValues(idVar, constraintValue, true);
+					}
+					else
+					{
+						builder.bindVar(_convertToUri(constraintValue), idVar, true);
+					}
+					break;
+				}
+				case "connector":
+				{
+					if(Array.isArray(constraintValue))
+					{
+						builder.addValues("c", constraintValue, true);
+						builder.append(`?s ${HKUris.USES_CONNECTOR_URI} ?c `);
+					}
+					else
+					{
+						builder.append(`?s ${HKUris.USES_CONNECTOR_URI} ${_convertToUri(constraint[k])} .`, true);
+					}
+					break;
+				}
+				case "className":
+				{
+					builder.append(`?s ${HKUris.CLASSNAME_URI} "${constraint[k]}" .`, true);
+					break;
+				}
+				case "properties":
+				{
+					builder.append(_filterForProperties(constraint[k]), true);
+					break;
+				}
+				case "binds":
+				{	
+					_filterForBinds(builder, constraintValue);
+					break;
+				}
+				default:
+				{
+					throw `Invalid filter: ${k}`;
+				}
+			}
+		}
+	}
+}
+
+function _checkIfHasNodeInConstraint(andFilters)
+{
+	for(let i = 0; i < andFilters.length; i++)
+	{
+		let item = andFilters[i];
+		for(let k in item)
+		{
+			if(k === "id" || k === "properties" || k === "parent")
+			{
+				return true;
+			}
+			else if(k === "type")
+			{
+				if(item[k] === "node" || item[k] === "context" || item[k] === "ref")
+				{
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
+function _filterForParent(builder, parent) {
+	if (Array.isArray(parent)) {
+		builder.addValues("g", parent, true);
+	}
+	else if (parent instanceof Object) {
+		const parentId = parent.parentId;
+		const includeNestedContexts = parent.includeNestedContexts;
+		if (includeNestedContexts) {
+			if (Array.isArray(parentId)) {
+				builder.addValues("g_root", parentId, true);
+			}
+			else
+			{
+				builder.bindVar(_convertToUri(parentId), "g_root", true);
+			}
+			builder.append(`?g ${HKUris.HAS_PARENT_URI}* ?g_root .`);
+		}
+
+		else {
+			builder.bindVar(_convertToUri(parentId), "g", true);
+		}
+	}
+
+	else {
+		builder.bindVar(_convertToUri(parent), "g", true);
+	}
+}
+
+function _filterForTypeArray(typeArray, idVar="s")
+{
+	let filter = '';
+	for(let i = 0; i < typeArray.length; i++)
+	{
+		const typeFilter = _filterForType(typeArray[i], idVar);
+		if(typeFilter !== null)
+		{
+			if(filter !== '')
+			{
+				filter += ' UNION ';
+			}
+			filter += ` { ${typeFilter} } `;
+		}
+	}
+	return filter;
+}
+
+function _filterForType(type, idVar = "s")
+{
+	switch(type)
+	{
+		case HKTypes.NODE:
+		{
+			return `?${idVar} ${HKUris.ISA_URI} ${HKUris.NODE_URI} . `;
+		}
+		case HKTypes.CONNECTOR:
+		{
+			return `?s ${HKUris.ISA_URI} ${HKUris.CONNECTOR_URI} . `;
+		}
+		case HKTypes.CONTEXT:
+		{
+			return `?${idVar} ${HKUris.ISA_URI} ${HKUris.CONTEXT_URI} . `;
+		}
+		case HKTypes.TRAIL:
+		{
+			return `?s ${HKUris.ISA_URI} ${HKUris.TRAIL_URI} . `;
+		}
+		case HKTypes.REFERENCE:
+		{
+			return `?s ${HKUris.ISA_URI} ${HKUris.REF_URI} . `;
+		}
+		case HKTypes.LINK:
+		{
+			return `?s ${HKUris.USES_CONNECTOR_URI} ?y . `;
+		}
+		default: 
+		{
+			return `?s ${HKUris.ISA_URI} ${_convertToUri(type)} . `;
+		}
+	}
+}
+
+function _filterForProperties(properties)
+{
+	let out = "";
+
+	for(let k in properties)
+	{
+		let v = properties[k];
+
+		let valueType = typeof v;
+
+		if(Array.isArray(v))
+		{
+			for(let i = 0; i < v.length; i++)
+			{
+				out += `{ ?s ${_convertToUri(k)} "${v[i]}" . } `;
+				if(i + 1 < v.length)
+				{
+					out += ' UNION ';
+				}
+			}
+		}
+		else if(valueType === "object")
+		{
+			// Assume $exist = true
+			out += `?s ${_convertToUri(k)} ?x . `;
+		}
+		else if(valueType === "number" || valueType === "boolean")
+		{
+			out += `?s ${_convertToUri(k)} ${v} . `;
+		}
+		else
+		{
+			out += `?s ${_convertToUri(k)} "${v}" . `;
+		}
+	}
+	return out;
+}
+
+function _convertToUri(id)
+{
+	if(!id)
+	{
+		return `<${Constants.HK_NULL}>`;
+	}
+	else if(Utils.isUri(id))
+	{
+		return id;
+	}
+	else if(Utils.isBlankNode(id))
+	{
+		return Utils.createBlankNodeUri(id.substr(2));
+	}
+	else
+	{
+		return `<${Utils.generateResourceFromId(id)}>`;
+	}
+}
+
+exports.FILTER_HK = FILTER_HK;
+exports.deleteTriples = deleteTriples;
+exports.getContextHierarchy = getContextHierarchy;
+exports.getAllEntities = getAllEntities;
+exports.getAllEntitiesLazy = getAllEntitiesLazy;
+exports.getRdf = getRdf;
+exports.getAllEntitiesUncompressed = getAllEntitiesUncompressed;
+exports.getEntities = getEntities;
+exports.removeEntities = removeEntities;
+exports.removeAllEntities = removeAllEntities;
+exports.filterEntities = filterEntities;
+exports.filterEntitiesSelect = filterEntitiesSelect;
+exports.filterEntitiesLazy = filterEntitiesLazy;
+exports.getLinks = getLinks;
+exports.updateTriples = updateTriples;
+exports.fromUris = fromUris;
+exports.getEntitiesFromUris = getEntitiesFromUris;

--- a/sparqlhelper.js
+++ b/sparqlhelper.js
@@ -1,0 +1,894 @@
+/*
+ * copyright: IBM Confidential
+ * copyright: OCO Source Materials
+ * copyright: © IBM Corp. All Rights Reserved
+ * date: 2020
+ *
+ * IBM Certificate of Originality
+ */
+"use strict";
+
+
+const SparqlJS = require("sparqljs");
+
+const BOOLEAN_XSD_URI = "http://www.w3.org/2001/XMLSchema#boolean";
+
+const HKUris = require("rdf2hk/hk");
+
+function traverseValues(values, out)
+{
+	for(let k in values)
+	{
+		let entry = values[k]
+
+		for(let j in entry)
+		{
+			let v = entry[j];
+
+			if(v.termType === "Literal") // Workaround to this bug: https://github.com/RubenVerborgh/SPARQL.js/issues/92
+			{
+				if(v.datatypeString === BOOLEAN_XSD_URI)
+				{
+					entry[j] = new v.constructor(`"${v.value.toLowerCase()}"^^${v.datatypeString}`);
+				}
+			}
+		}
+	}
+}
+
+function traverseBGP(triples, out, state)
+{
+	for(let i = 0; i < triples.length; i++)
+	{
+		let t = triples[i];
+
+		if(!state.skipBgp)
+		{
+			if(t.subject.termType === "Variable")
+			{
+				out.subjects.add(t.subject.value)
+			}
+			if(t.predicate.termType === "Variable")
+			{
+				out.predicates.add(t.predicate.value)
+			}
+			if(t.object.termType === "Variable")
+			{
+				out.objects.add(t.object.value);
+			}
+		}
+
+		if(t.object.termType === "Literal") // Workaround to this bug: https://github.com/RubenVerborgh/SPARQL.js/issues/92
+		{
+			if(t.object.datatypeString === BOOLEAN_XSD_URI)
+			{
+				t.object = new t.object.constructor(`"${t.object.value.toLowerCase()}"^^${t.object.datatypeString}`);
+			}
+		}
+
+		// console.log(t);
+	}
+
+}
+
+function traverseOperation(operation, out)
+{
+	for(let i = 0; i < operation.args.length; i++)
+	{
+		let o = operation.args[i];
+
+		if(o.termType)
+		{
+			if(o.termType === "Literal")
+			{
+				if(o.datatypeString === BOOLEAN_XSD_URI)
+				{
+					operation.args[i] = new o.constructor(`"${o.value.toLowerCase()}"^^${o.datatypeString}`);
+				}
+			}
+		}
+		else if(o.type === "expression")
+		{
+			traverseExpression(o, out);
+		}
+		else if(o.type === "operation")
+		{
+			traverseOperation(o, out);
+		}
+	}
+}
+
+function traverseExpression(expression, out)
+{
+	if(expression.type === "operation")
+	{
+		traverseOperation(expression, out)
+	}
+}
+
+function traverseFilter(filter, out)
+{
+	if(filter.expression)
+	{
+		traverseExpression(filter.expression, out);
+	}
+}
+
+function traverseGraph(graph, out)
+{
+	if(graph.name)
+	{
+		out.graphs.add(graph.name.value);
+	}
+}
+
+function generalTraverse(parts, out, state)
+{
+	for(let i = 0; i < parts.length; i++)
+	{
+		let n = parts[i];
+
+		// console.log(n);
+
+		switch(n.type)
+		{
+			case "bgp":
+				traverseBGP(n.triples, out, state);
+				break;
+			case "graph":
+				traverseGraph(n, out, state);
+			case "group":
+				generalTraverse(n.patterns, out, state);
+				break;
+			case "query":
+				traverseQuery(n, out, state)
+				break;
+			case "filter":
+				traverseFilter(n, out, state);
+				break;
+			case "optional":
+				// console.log(n);
+				generalTraverse(n.patterns, out, {skipBgp: true});
+				break;
+			case "bind":
+				break;
+			case "union":
+				generalTraverse(n.patterns, out, state)
+				break;
+			case "values":
+				traverseValues(n.values, out, state);
+				break;
+			default:
+				console.log("Unknown term?", n.type);
+				break;
+
+		}
+	}
+}
+
+function traverseQuery(query, out, state)
+{
+	state = state || {skipBgp: false};
+	out.queries.push(query);
+	let parts = query.where;
+
+
+	generalTraverse(parts, out, state);
+}
+
+function setHKFiltered(query)
+{
+	try
+	{
+		let sparqlParser = new SparqlJS.Parser();
+		let sparqlGenerator = new SparqlJS.Generator();
+
+		let sparqlObj = sparqlParser.parse(query);
+
+		let filteredSparqlParser = new SparqlJS.Parser();
+
+		let out = {subjects: new Set(),
+				  predicates: new Set(),
+				  objects: new Set(),
+				  graphs: new Set(),
+				  queries: []};
+
+		// console.log(sparqlObj);
+
+		traverseQuery(sparqlObj, out);
+
+		for(let i = 0; i < out.queries.length; i++)
+		{
+			let query = out.queries[i];
+
+			let queryTraversal = {subjects: new Set(),
+				predicates: new Set(),
+				objects: new Set(),
+				graphs: new Set(),
+				queries: []};
+
+			traverseQuery(query, queryTraversal);
+
+			// console.log(queryTraversal);
+			// console.log(queryTraversal.predicates);
+
+			let temp = {filters: ""}
+
+			let subjects = Array.from(queryTraversal.subjects);
+
+			let predicates = Array.from(queryTraversal.predicates);
+
+			let objects = Array.from(queryTraversal.objects);
+
+			let graphs = Array.from(queryTraversal.graphs);
+
+			if(subjects.length === 0 && predicates.length === 0 && objects.length === 0 && graphs.length === 0)
+			{
+				continue;
+			}
+
+			let first = false;
+
+			// add filters for graph variables. 
+			// Only works properly if triples are not imported in hk://id/null
+			// for(let i = 0; i < graphs.length; i++)
+			// {
+			// 	let v = graphs[i];
+			// 	variables += `?${v} `;
+
+			// 	if( first )
+			// 	{
+			// 		temp.filters += " && ";
+			// 	}
+			// 	filterGraphsForHK(v, temp);
+			// 	first = true;
+			// }
+
+			let variables = new Set();
+
+			for(let i = 0; i < subjects.length; i++)
+			{
+				let v = subjects[i];
+				variables.add(`?${v}`);
+
+				if( first )
+				{
+					temp.filters += " && ";
+				}
+				filterSubjectsForHK(v, temp);
+				first = true;
+			}
+
+			// add filters for predicate variables
+			for(let i = 0; i < predicates.length; i++)
+			{
+				let v = predicates[i];
+				variables.add(`?${v}`);
+
+				if( first )
+				{
+					temp.filters += " && ";
+				}
+				filterPredicatesForHK(v, temp);
+				first = true;
+			}
+
+			// add filters for object variables
+			for(let i = 0; i < objects.length; i++)
+			{
+				let v = objects[i];
+				variables.add(`?${v}`);
+
+				if( first )
+				{
+					temp.filters += " && ";
+				}
+				filterObjectsForHK(v, temp);
+				first = true;
+			}
+
+
+			let filteredQuery = `select ${[...variables].join(' ')} where { filter(${temp.filters}) }`;
+
+			// console.log(filteredQuery);
+
+			let filteredQueryObject = filteredSparqlParser.parse(filteredQuery);
+
+			query.where = query.where.concat(filteredQueryObject.where);
+		}
+
+		let outQuery = sparqlGenerator.stringify(sparqlObj);
+
+		// console.log(outQuery);
+
+		return outQuery;
+	}
+	catch(exp)
+	{
+		console.log(exp);
+		console.log("Warning: Failed to parse query to inject filters. Skipped.");
+		// console.log(query);
+		return query;
+	}
+
+}
+
+function filterPredicatesForHK (variable, filters)
+{
+	if(!variable.startsWith("?"))
+	{
+		variable = "?" + variable;
+	}
+	filters.filters += `(
+		!BOUND(${variable}) || 
+		(
+			${variable} != ${HKUris.ISA_URI} &&
+			${variable} != ${HKUris.USES_CONNECTOR_URI}  &&
+			${variable} != ${HKUris.CLASSNAME_URI} &&
+			${variable} != ${HKUris.REFERENCES_URI} &&
+			${variable} != ${HKUris.HAS_PARENT_URI} &&
+			!STRSTARTS(STR(${variable}), "hk://role") &&
+			!STRSTARTS(STR(${variable}), "hk://b/") &&
+			!STRSTARTS(STR(${variable}), "hk://link")
+		)
+	)`;
+}
+
+function filterSubjectsForHK (variable, filters)
+{
+	if(!variable.startsWith("?"))
+	{
+		variable = "?" + variable;
+	}
+	const reservedURIFilters = `(${variable} != ${HKUris.ISA_URI} &&
+								${variable} != ${HKUris.USES_CONNECTOR_URI}  &&
+								${variable} != ${HKUris.CLASSNAME_URI} &&
+								${variable} != ${HKUris.REFERENCES_URI} &&
+								${variable} != ${HKUris.HAS_PARENT_URI} )`;
+	const stringBasedFilters =  `!( ISIRI(${variable}) && ( STRSTARTS(STR(${variable}), "hk://role") || STRSTARTS(STR(${variable}), "hk://link") || STRSTARTS(STR(${variable}), "hk://b/") ) )`;
+	const functionBasedFilters = `( isIRI(${variable}) || isBlank(${variable}) ||  datatype(${variable}) != ${HKUris.DATA_LIST_URI} )`;
+	filters.filters += `(
+		!BOUND(${variable}) ||
+		( 
+			${reservedURIFilters} && ${stringBasedFilters} && ${functionBasedFilters} 
+		)
+	)`;
+}
+
+function filterObjectsForHK (variable, filters)
+{
+	if(!variable.startsWith("?"))
+	{
+		variable = "?" + variable;
+	}
+	const stringBasedFilters =  `!( ISIRI(${variable}) && ( STRSTARTS(STR(${variable}), "hk://role") || STRSTARTS(STR(${variable}), "hk://link") || STRSTARTS(STR(${variable}), "hk://b/") ) )`;
+	const functionBasedFilters = `( isIRI(${variable}) || isBlank(${variable}) ||  datatype(${variable}) != ${HKUris.DATA_LIST_URI} )`;
+	filters.filters += `(
+		!BOUND(${variable}) ||
+		( 
+			${stringBasedFilters} && ${functionBasedFilters} 
+		)
+	)`;
+}
+
+function optimizeFilter (filters)
+{
+	let out = [];
+
+	let clusters = {};
+
+	let addPairToCluster = (key)=>
+	{
+		if(!clusters.hasOwnProperty(key))
+		{
+			clusters[key] = 1;
+		}
+		else
+		{
+			clusters[key] = clusters[key] + 1;;	
+		}
+	}
+
+	let getHashes = (andFilters) =>
+	{
+		let hashes = [];
+
+		for(let j = 0; j < andFilters.length; j++)
+		{
+			let constraint = andFilters[j];
+
+			for(let k in constraint)
+			{
+				let v = constraint[k];
+
+				if(typeof v === "object")
+				{
+					for(let i in v)
+					{
+						let pair = `${k}.${i}=${v[i]}`;
+						hashes.push(pair);
+					}
+				}
+				else
+				{
+					let pair = `${k}=${v}`;
+					hashes.push(pair);
+				}
+			}
+
+		}
+
+		return hashes;
+	}
+
+	for(let i = 0; i < filters.length; i++)
+	{
+		let andFilters = filters[i];
+
+		let hashes = getHashes(andFilters);
+		for(let h of hashes)
+		{
+			addPairToCluster(h);
+		}
+		out.push(andFilters);
+	}
+
+
+	filters.sort((a, b) =>
+	{
+		let hashesA = getHashes(a);
+		let hashesB = getHashes(b);
+
+		if(hashesA.length < hashesB.length)
+		{
+			return -1;
+		}
+		else if(hashesA.length > hashesB.length)
+		{
+			return 1;
+		}
+		else
+		{
+			let aCounts = [];
+			for(let i = 0; i < hashesA.length; i++)
+			{
+				aCounts.push(clusters[hashesA[i]]);
+			}
+			let bCounts = [];
+			for(let i = 0; i < hashesB.length; i++)
+			{
+				bCounts.push(clusters[hashesA[i]]);
+			}
+
+			aCounts.sort();
+			bCounts.sort();
+
+			let ka = aCounts.join("_");
+			let kb = bCounts.join("_");
+
+			if(ka < kb)
+			{
+				return -1;
+			}
+			else if(kb < ka)
+			{
+				return -1;
+			}
+			else 
+			{	
+				hashesA.sort();
+				hashesB.sort();
+
+				let ha = hashesA.join(";");
+				let hb = hashesB.join(";");
+
+				if(ha < hb)
+				{
+					return -1;
+				}
+				else if(ha > hb)
+				{
+					return 1;
+				}
+				return 0;
+			}
+
+
+		}
+
+	});
+
+	let optimized = [];
+
+	// console.log(">>>>>>>");
+	// console.log(JSON.stringify(filters, null, 2));
+
+	let last = filters[0];
+
+	let willBreak = false;
+	for(let i = 1; i < filters.length; i++)
+	{
+		let item = filters[i];
+
+
+		let pendingValue = null;
+		let pendingKey = null;
+		let pendingProperty = null;
+		let foundWildcard = false;
+		for(let i = 0 ; i < item.length; i++)
+		{
+			let c1 = item[i];
+
+			for(let k in c1)
+			{
+				for(let j = 0; j < last.length; j++)
+				{
+					let c2 = last[j];
+
+
+					if(c2.hasOwnProperty(k))
+					{
+						if(Array.isArray(c2[k]))
+						{
+							if(!foundWildcard)
+							{
+								foundWildcard = true;
+								pendingValue = c1[k];
+								pendingKey = k;
+								pendingProperty = c2;
+							}
+							else
+							{
+								optimized.push(last);
+								last = item;
+								willBreak = true;
+								break;
+							}
+						}
+						else if(typeof c2[k] === "object" && typeof c1[k] === "object")
+						{
+							let v1 = c1[k];
+							let v2 = c2[k];
+
+							for(let x in v1)
+							{
+								if(Array.isArray(v2[x]))
+								{
+									if(!foundWildcard)
+									{
+										foundWildcard = true;
+										pendingValue = v1[x];
+										pendingKey = x;
+										pendingProperty = v2;
+									}
+									else
+									{
+										optimized.push(last);
+										last = item;
+										willBreak = true;
+										break;
+									}
+								}
+								else if(v2.hasOwnProperty(x))
+								{
+									if(v1[x] !== v2[x])
+									{
+										if(!foundWildcard)
+										{
+											foundWildcard = true;
+											pendingValue = v1[x];
+											pendingKey = x;
+											pendingProperty = v2;
+										}
+										else
+										{
+											optimized.push(last);
+											last = item;
+											willBreak = true;
+											break;
+										}
+									}
+									
+								}
+								else
+								{
+									optimized.push(last);
+									last = item;
+									willBreak = true;
+									break;
+								}
+							}
+						}
+						else
+						{
+							if(c1[k] !== c2[k])
+							{
+								if(foundWildcard)
+								{
+									optimized.push(last);
+									last = item;
+									willBreak = true;
+									break;
+								}
+								else
+								{
+									pendingValue = c1[k];
+									pendingKey = k;
+									pendingProperty = c2;
+									foundWildcard = true;
+								}
+							}
+						}
+					}
+					else
+					{
+						optimized.push(last);
+						last = item;
+						willBreak = true;
+						break;
+					}
+				}
+
+				if(willBreak)
+				{
+					break;
+				}
+			}
+			if(willBreak)
+			{
+				break;
+			}
+		}
+
+		if(!willBreak && pendingValue && pendingProperty && pendingKey)
+		{
+			if(!Array.isArray(pendingProperty[pendingKey]))
+			{
+				pendingProperty[pendingKey] = [pendingProperty[pendingKey]];
+			}
+
+			pendingProperty[pendingKey].push(pendingValue);
+		}
+		willBreak = false;
+
+	}
+	optimized.push(last);
+
+	// console.log(JSON.stringify(clusters, null, 2));
+
+	
+	// console.log("*******");
+	// console.log(JSON.stringify(optimized, null, 2));
+
+	// console.log("results", filters.length, optimized.length);
+	return optimized;
+}
+
+function optimizeFilter2 (filters)
+{
+	const clusters          = {};
+	const bindClusters      = {};
+	const bindConnClusters  = {};
+
+	let out = [];
+
+	let map = {};
+
+	let bindsArray = [];
+
+	for(let i = 0; i < filters.length; i++)
+	{
+		let andFilters = filters[i];
+
+		let currentConstraint = [];
+		
+
+		if(andFilters.length === 1)
+		{
+			for(let j = 0; j < andFilters.length; j++)
+			{
+				let constraint = andFilters[j];
+
+				let keys = Object.keys(constraint);
+
+				// if(constraint.binds || constraint.connector)
+				// {
+				// 	for(let k in constraint)
+				// 	{
+				// 		let v = constraint[k];
+
+				// 		if(k === "binds")
+				// 		{
+				// 			for(let b in v)
+				// 			{
+				// 				let pair = `binds=${b}_${v[b]}`;
+				// 				if(!map.hasOwnProperty(pair))
+				// 				{
+				// 					map[pair] = 1;
+				// 				}	
+				// 				else
+				// 				{
+				// 					map[pair] = map[pair] +1;
+				// 				}
+				// 			}
+				// 		}
+				// 		else
+				// 		{
+				// 			let pair = `${k}=${v}`;
+				// 			if(!map.hasOwnProperty(pair))
+				// 			{
+				// 				map[pair] = 1;
+				// 			}	
+				// 			else
+				// 			{
+				// 				map[pair] = map[pair] +1;
+				// 			}
+				// 		}
+				// 	}
+
+				// 	bindsArray.push(constraint);
+
+				// }
+				if(keys.length === 2)
+				{
+					if(constraint.binds && constraint.connector && Object.keys(constraint.binds).length === 1)
+					{
+						if(!bindConnClusters.hasOwnProperty(constraint.connector))
+						{
+							bindConnClusters[constraint.connector] = {};
+						}
+
+						let role = Object.keys(constraint.binds)[0];
+						let binds = bindConnClusters[constraint.connector];
+						
+						if(!binds.hasOwnProperty(role))
+						{
+							binds[role] = new Set();
+						}
+						binds[role].add(constraint.binds[role]);
+					}
+					else
+					{
+						currentConstraint.push(constraint);	
+					}
+				}
+				else 
+				if(keys.length === 1)
+				{
+					let k = keys[0];
+					let v = constraint[k];
+					switch(k)
+					{
+						case "parent":
+						case "ref":
+						case "id":
+						case "connector":
+							if(!clusters.hasOwnProperty(k))
+							{
+								clusters[k] = new Set();
+							}
+							clusters[k].add(v);
+						break;
+						case "binds":
+							let role = Object.keys(constraint[k])[0];
+							if(!bindClusters.hasOwnProperty(role))
+							{
+								bindClusters[role] = new Set();
+							}
+							bindClusters[role].add(v[role]);
+
+							break;
+						default:
+							// out.push([constraint]);
+							currentConstraint.push(constraint);
+						break;
+
+					}
+				}
+				else
+				{
+					// out.push([constraint]);
+					currentConstraint.push(constraint);
+				}
+			}
+			if(currentConstraint.length > 0)
+			{
+				out.push(currentConstraint);
+			}
+		}
+		else
+		{
+			out.push(andFilters);
+		}
+	}
+
+	// console.log(map);
+
+	// bindsArray.sort((a, b) =>
+	// {
+	// 	let a1 = [];
+	// 	for(let k in a)
+	// 	{
+	// 		if(k === "binds")
+	// 		{
+	// 			for(let b in v)
+	// 			{
+	// 				let pair = `binds=${b}_${v[b]}`;
+	// 				a1.push(map[pair]);
+	// 			}
+	// 		}
+	// 		else
+	// 		{
+	// 			let pair = `${k}=${v}`;
+	// 			a1.push(pair);
+	// 		}
+	// 	}	
+	// 	let b1 = [];
+	// 	for(let k in b)
+	// 	{
+	// 		if(k === "binds")
+	// 		{
+	// 			for(let b in v)
+	// 			{
+	// 				let pair = `binds=${b}_${v[b]}`;
+	// 				b1.push(pair);
+	// 			}
+	// 		}
+	// 		else
+	// 		{
+	// 			let pair = `${k}=${v}`;
+	// 			b1.push(pair);
+	// 		}
+	// 	};
+
+	// 	let out = 0;
+	// 	for(let i of a1)
+	// 	{
+	// 		for(let j of b1)
+	// 		{
+
+	// 		}
+	// 	}
+	// })
+
+	if(Object.keys(clusters).length > 0)
+	{
+		for(let k in clusters)
+		{
+			let optimized = {}
+			optimized[k] = Array.from(clusters[k]);
+			out.push([optimized]);
+		}
+	}
+
+	if(Object.keys(bindClusters).length > 0)
+	{
+		for(let k in bindClusters)
+		{
+			let optimized = {binds: {}};
+			optimized.binds[k] = Array.from(bindClusters[k]);
+			out.push([optimized]);
+		}
+	}
+
+	if(Object.keys(bindConnClusters).length > 0)
+	{
+		for(let k in bindConnClusters)
+		{
+			let binds = bindConnClusters[k];
+
+			for(let role in binds)
+			{
+				let optimized = {connector: k, binds: {}};
+				optimized.binds[role] = Array.from(binds[role]);
+				out.push([optimized]);
+			}
+		}
+	}
+
+	return out;
+}
+
+exports.optimizeFilter  = optimizeFilter;
+exports.filterForHK = filterPredicatesForHK;
+exports.setHKFiltered = setHKFiltered;

--- a/updatehelper.js
+++ b/updatehelper.js
@@ -1,0 +1,213 @@
+/*
+ * copyright: IBM Confidential
+ * copyright: OCO Source Materials
+ * copyright: © IBM Corp. All Rights Reserved
+ * date: 2020
+ *
+ * IBM Certificate of Originality
+ */
+"use strict";
+
+const Utils = require("./utils");
+const Serializer = require("./serializer");
+const GraphFactory = require("./graphfactory");
+const HK = require("./hk");
+const Types = require("hklib/types");
+
+function serializeToUpdate(entities, oldEntities, conversionOptions)
+{
+	let changedParents = {};
+	let changeEntities = {};
+
+	for(let k in entities)
+	{
+		let entity = entities[k];
+
+		if(!entity.id)
+		{
+			continue;
+		}
+
+		if(entity.properties || entity.metaProperties || (entity.interfaces || entity.interfaces === null) || entity.className)
+		{
+			let triples = [];
+			let propertiesSet = new Set();
+			let metaProperties = {};
+
+			// Collect properties and metaproperties that are being modified
+			let metaAndProperties = Object.keys(entity.properties || {});
+			metaAndProperties = metaAndProperties.concat(Object.keys(entity.metaProperties || {}) || []);
+			propertiesSet = new Set(metaAndProperties);
+			
+			let interfaceChanges = _evaluateInterfacesChanges(entity);
+
+			if(propertiesSet.size > 0 || interfaceChanges.interfacesKeys.length > 0 || entity.className)
+			{
+				triples = _convertEntityToTriples(entity, conversionOptions, interfaceChanges.interfacesToUpdate, propertiesSet);
+				
+			} 
+			else if(entity.interfaces === null && oldEntities.hasOwnProperty(entity.id))
+			{
+				entity.interfaces = oldEntities[entity.id].interfaces || {};
+				for(let interfaceKey in entity.interfaces)
+				{
+					entity.interfaces[interfaceKey] = null;
+				}
+				interfaceChanges = _evaluateInterfacesChanges(entity);
+				triples = _convertEntityToTriples(entity, conversionOptions, interfaceChanges.interfacesToUpdate, propertiesSet);
+			}
+
+			let changes = {properties: Array.from(propertiesSet),  
+						   interfacesToUpdate: interfaceChanges.interfacesToUpdate,
+						   interfacesToRemove: interfaceChanges.interfacesToRemove,
+						   interfacesPropertites: interfaceChanges.interfacesProperties,
+						   metaProperties: metaProperties,
+						   triples: triples,};
+			changeEntities[entity.id] = changes;
+		}
+
+		// Collect entities that being reparent
+		if(entity.hasOwnProperty("parent"))
+		{
+			changedParents[entity.id] = entity.parent;
+		}
+	}
+
+	return {changedEntities: changeEntities, changedParents: changedParents};
+}
+
+function _convertEntityToTriples(entity, conversionOptions, interfacesToUpdate, propertiesSet = new Set())
+{
+	let obj = {id: entity.id, 
+		properties: entity.properties || {}, 
+		metaProperties: entity.metaProperties || {},
+		interfaces: interfacesToUpdate};
+
+	if(entity.type === Types.REFERENCE)
+	{
+		obj.type = Types.REFERENCE;
+		obj.ref = entity.ref;
+	}
+
+	if(entity.type === Types.CONNECTOR)
+	{
+		propertiesSet.add(HK.CLASSNAME_URI);
+		obj.className = entity.className;
+        	obj.type = Types.CONNECTOR;
+        	obj.roles = entity.roles;
+        
+	}
+
+	if(entity.hasOwnProperty("parent"))
+	{
+		obj.parent = entity.parent;
+	}
+
+	let graph = GraphFactory.createGraph("application/json",true);
+	Serializer.serialize([obj], conversionOptions, graph);
+	let triples = [];
+	// Escape literal, this is for sparql
+	graph.forEachStatement((s, p, o, g) =>
+	{
+		// let t = triples[i];
+		let t = [s, p, o, g];
+
+		if(!Utils.isUriOrBlankNode(t[2]))
+		{
+			let info = {};
+
+			let v = Utils.getValueFromLiteral(t[2], info);
+
+			// Escape string literal
+			let hasBreakLine = v.search("\n");
+
+
+			let escapedQuote = hasBreakLine > 0 ? "\\\"\"\"" :  "\\\"";
+			let q = hasBreakLine > 0 ? "\"\"\"" :  "\"";
+
+			if(! conversionOptions.noEscape)
+			{
+				v = JSON.stringify(v).slice(1, -1);
+			}
+				
+			if(hasBreakLine >= 0)
+			{
+				v = v.replace(new RegExp(q, "ig"), escapedQuote);
+			}
+
+			if(info.type)
+			{
+				let type = Utils.isUri(info.type) ? info.type : `<${Utils.generateResourceFromId(info.type)}>`;
+				t[2] = `${q}${v}${q}^^${type}`;
+			}
+			else if(info.lang)
+			{
+				t[2] = `${q}${v}${q}@${info.lang}`;
+			}
+			else
+			{
+				if( ! conversionOptions.noEscape)
+				{
+					t[2] = `${q}${v}${q}`;
+				}
+				else
+				{
+					let literal = v.split("^^");
+					if(literal[1])
+					{
+						t[2] = `${literal[0]}^^<${Utils.generateResourceFromId(literal[1])}>`;
+					}
+					else
+					{
+						t[2] = `${q}${v}${q}`;
+					}
+					
+				}
+			}
+
+		}
+
+		triples.push(t);
+	});
+
+	return triples;
+}
+
+function _evaluateInterfacesChanges(entity)
+{
+	// Collect interfaces
+	let interfs = entity.interfaces || {};
+	let interfacesKeys = Object.keys(interfs);
+
+	let interfacesToRemove = [];
+	let interfacesToUpdate = {};
+	let interfacesProperties = {};
+
+	for(let k in interfs)
+	{
+		let interf = interfs[k];
+		if(interf)
+		{
+			interfacesToUpdate[interf.key || k] = interf ;
+			let properties = Object.keys(interf.properties || {});
+
+			if(properties.length > 0)
+			{
+				interfacesProperties[interf.key || k] = properties;
+			}
+		}
+		else
+		{
+			interfacesToRemove.push(k);
+		}
+	}
+	
+	return {
+		interfacesKeys: interfacesKeys,
+		interfacesToRemove: interfacesToRemove,
+		interfacesToUpdate: interfacesToUpdate,
+		interfacesProperties: interfacesProperties
+	};
+}
+
+exports.serializeToUpdate = serializeToUpdate;


### PR DESCRIPTION
Moving sparql builder, factory, helper and update helper to this library as they are highly dependent on how the HK entities are serialized in RDF. 

Also, having these components in this library enables greater reuse across datasources, reducing code replication.

In the future, we might move these classes to a new library, but due to this high dependency with how the entities are serialized it also makes sense to keep them here.