### PR TITLE
Updating workaround of the sparqljs with group by clauses to consider subqueries.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rdf2hk",
-	"version": "1.3.7",
+	"version": "1.3.8",
 	"description": "This library converts RDF to Hyperknowledge Description",
 	"main": "index.js",
 	"author": "IBM Research",


### PR DESCRIPTION
For example, in version 1.3.7, when parsing and unparsing the following sparql query we prevented the addition of round brackets to the elements of the group by:

```
select ?g  (count( ?s ) as ?count)
{
  ...
}
group by ?g
```

But we didn't consider subqueries. Therefore, the round bracket problem still occurs: 

```
select ?g ?t ?count
{
    select ?g  (count( ?s ) as ?count)
    {
      ...
    }
    group by ( ?g) # These round brackets cause errors in some triplestores.
}
```

This PR fix that problem.
