### PR TITLE
Removing unnecessary traversal from add filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rdf2hk",
-	"version": "1.5.3",
+	"version": "1.5.4",
 	"description": "This library converts RDF to Hyperknowledge Description",
 	"main": "index.js",
 	"author": "IBM Research",

--- a/sparqlhelper.js
+++ b/sparqlhelper.js
@@ -202,13 +202,7 @@ function setHKFiltered(query)
 		{
 			let query = out.queries[i];
 
-			let queryTraversal = {subjects: new Set(),
-				predicates: new Set(),
-				objects: new Set(),
-				graphs: new Set(),
-				queries: []};
-
-			traverseQuery(query, queryTraversal);
+			let queryTraversal = out;
 
 			let temp = {filters: ""}
 


### PR DESCRIPTION
The method `setHKFiltered` for each inner query in the given sparql query, the code was executing another traversal to create the object `queryTraversal`. Given that the methods using this second object had no side effects, that is, the object itself is not being modified, we can reuse the `out` variable in all iterations.