### PR TITLE
Wrapping inner queries with a group 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rdf2hk",
-	"version": "1.5.4",
+	"version": "1.5.5",
 	"description": "This library converts RDF to Hyperknowledge Description",
 	"main": "index.js",
 	"author": "IBM Research",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rdf2hk",
-	"version": "1.5.3",
+	"version": "1.5.4",
 	"description": "This library converts RDF to Hyperknowledge Description",
 	"main": "index.js",
 	"author": "IBM Research",

--- a/sparqlhelper.js
+++ b/sparqlhelper.js
@@ -275,6 +275,15 @@ function setHKFiltered(query)
 
 			let filteredQueryObject = filteredSparqlParser.parse(filteredQuery);
 
+			if (query.where.length == 1 && query.where[0].type == 'query') {
+				// should create a group that contains the current where...
+				let newGroup = {
+					type: 'group', 
+					patterns: [query.where[0]]
+				};
+				query.where[0] = newGroup;
+			}
+			
 			query.where = query.where.concat(filteredQueryObject.where);
 		}
 


### PR DESCRIPTION
# Current Behavior

Currently, adding filters to SPARQL queries that have where clauses composed solely of a inner query creates invalid sparql queries.

# Example:

Queries of the type: 

```
select ?c { 

    select (count(?s) as ?c) {
      ?s ?p ?o .
    }
} 
```

Are transformed into: 

```
select ?c { 

    select (count(?s) as ?c) {
      ?s ?p ?o .
    }

  filter(<variables and predicates filters>)
} 
```