### PR TITLE
Fix#agraph parent filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rdf2hk",
-	"version": "1.5.6",
+	"version": "1.5.7",
 	"description": "This library converts RDF to Hyperknowledge Description",
 	"main": "index.js",
 	"author": "IBM Research",

--- a/sparqlfactory.js
+++ b/sparqlfactory.js
@@ -306,7 +306,7 @@ function filterEntitiesSelect (filters)
 					});
 
 					let filteredAndFilters = andFilters.filter(filter => {
-						if (filter.hasOwnProperty("id")) return false;
+						if (filter.hasOwnProperty("id") || (filter.hasOwnProperty("parent") && !(filter.parent instanceof Object)) ) return false;
 						return true;
 					})
 


### PR DESCRIPTION
Adding more filters to deal with issues when executing over an allegro graph datasource. For some reason, running the following filter in an agraph datasource returns more entities than expected:

`{"parent": null, type:"node"}`

This was returning all node entities.