### PR TITLE
Fixing blanknode serialization

### DIFF
--- a/hk.js
+++ b/hk.js
@@ -30,6 +30,7 @@ exports.HAS_BIND_URI          = '<http://research.ibm.com/ontologies/graph#hasBi
 exports.HAS_PARENT_URI        = '<http://research.ibm.com/ontologies/graph#hasParent>';
 exports.ISA_URI               = '<http://research.ibm.com/ontologies/graph#isa>';
 exports.REFERENCES_URI        = '<http://research.ibm.com/ontologies/graph#references>';
+exports.REFERENCED_BY_URI     = '<http://research.ibm.com/ontologies/graph#referencedBy>';
 exports.USES_CONNECTOR_URI    = '<http://research.ibm.com/ontologies/graph#usesConnector>';
 exports.HAS_BLANK_ID_URI      = '<http://research.ibm.com/ontologies/graph#hasBlankId>';
 

--- a/hkparser.js
+++ b/hkparser.js
@@ -25,6 +25,7 @@ const HYPERKNOWLEDGE_URIS = new Set();
 
 HYPERKNOWLEDGE_URIS.add(HKUris.HAS_PARENT_URI);
 HYPERKNOWLEDGE_URIS.add(HKUris.REFERENCES_URI);
+HYPERKNOWLEDGE_URIS.add(HKUris.REFERENCED_BY_URI);
 HYPERKNOWLEDGE_URIS.add(HKUris.USES_CONNECTOR_URI);
 
 HYPERKNOWLEDGE_URIS.add(HKUris.HAS_BIND_URI);
@@ -222,6 +223,11 @@ HKParser.prototype.setIntrinsicProperties = function (s, p, o, g, spo)
           entity.ref = Utils.getIdFromResource(o);
           break;
         }
+      case HKUris.REFERENCED_BY_URI:
+      {
+        entity.ref = Utils.getIdFromResource(s);
+        break;
+      }
       case HKUris.USES_CONNECTOR_URI:
         {
           entity.connector = Utils.getIdFromResource(o);

--- a/hkserializer.js
+++ b/hkserializer.js
@@ -182,7 +182,7 @@ HKSerializer.prototype.serialize = function(entity)
 				let uri = Utils.createBlankNodeUri(entityUri.substr(2));
 				
 				graph.add(uri, this.isAPredicate, this.nodeResourceType, parentUri);
-				graph.add(uri, hk.REFERENCES_URI, entityUri, parentUri);
+				graph.add(entityUri, hk.REFERENCED_BY_URI, uri, parentUri);
 			}
 			else
 			{

--- a/hkserializer.js
+++ b/hkserializer.js
@@ -197,7 +197,11 @@ HKSerializer.prototype.serialize = function(entity)
             let referencedNode = entity.ref;
 
             graph.add(entityUri, this.isAPredicate, this.refResourceType, parentUri);
-			if(this.inverseRefNode)
+            if(Utils.isBlankNode(entityUri))
+            {
+                graph.add(referencedNode, hk.REFERENCED_BY_URI, entityUri, parentUri);
+            }
+			else if(this.inverseRefNode)
 			{
 				graph.add(entityUri, hk.REFERENCES_URI, referencedNode, parentUri);
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rdf2hk",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "This library converts RDF to Hyperknowledge Description",
   "main": "index.js",
   "author": "IBM Research",

--- a/simpleowlparser.js
+++ b/simpleowlparser.js
@@ -72,7 +72,12 @@ class SimpleOwlParser
 
   createConnectors(s, p, o, g, spo)
   {
-    if ((p === rdf.TYPE_URI && owl.OBJECT_PROPERTY_URIS.includes(o)) || owlVocabulary.has(p))
+    if (
+      !Utils.isBlankNode(s) && (
+        (p === rdf.TYPE_URI && owl.OBJECT_PROPERTY_URIS.includes(o)) || 
+        owlVocabulary.has(p)
+      )
+    )
     {
       if (!this.entities.hasOwnProperty(s))
       {
@@ -90,8 +95,12 @@ class SimpleOwlParser
 
   createRelationships(s, p, o, g)
   {
-    if ((p === rdf.TYPE_URI && !owl.OBJECT_PROPERTY_URIS.includes(o)) ||
-      (owlVocabulary.has(p)))
+    if (
+      !Utils.isBlankNode(s) && (
+        (p === rdf.TYPE_URI && !owl.OBJECT_PROPERTY_URIS.includes(o)) ||
+        (owlVocabulary.has(p))
+      )
+    )
     {
       let refID = Utils.createRefUri(s, g);
       let ref = null;

--- a/sparqlhelper.js
+++ b/sparqlhelper.js
@@ -340,6 +340,7 @@ function filterPredicatesForHK (variable, filters)
 			${variable} != ${HKUris.USES_CONNECTOR_URI}  &&
 			${variable} != ${HKUris.CLASSNAME_URI} &&
 			${variable} != ${HKUris.REFERENCES_URI} &&
+			${variable} != ${HKUris.REFERENCED_BY_URI} &&
 			${variable} != ${HKUris.HAS_PARENT_URI} &&
 			${variable} != ${HKUris.DATA_LITERAL_URI} &&
 			!STRSTARTS(STR(${variable}), "hk://role") &&


### PR DESCRIPTION
In previous RDF2HK versions, the blanknode serialization was able to produce the following result:
```
<http://swat.cse.lehigh.edu/onto/univ-bench.owl#Employee>
        a       <http://www.w3.org/2002/07/owl#Class> ;
        <http://www.w3.org/2000/01/rdf-schema#label>
                "Employee" ;
        <http://research.ibm.com/ontologies/graph#isa>
                <http://research.ibm.com/ontologies/graph#node> ;
        <http://www.w3.org/2002/07/owl#intersectionOf>
                [ <http://www.w3.org/1999/02/22-rdf-syntax-ns#first>
                          <http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person> ;
                  <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest>
                          [ <http://www.w3.org/1999/02/22-rdf-syntax-ns#first>
                                    [ a       <http://www.w3.org/2002/07/owl#Restriction> ;
                                      <http://research.ibm.com/ontologies/graph#referencedBy>
                                              <hk://b/f874a1a9-68c2-11ec-a469-7b1028dfc5e7> ;
                                      <http://www.w3.org/2002/07/owl#onProperty>
                                              <http://swat.cse.lehigh.edu/onto/univ-bench.owl#worksFor> ;
                                      <http://www.w3.org/2002/07/owl#someValuesFrom>
                                              <http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization>
                                    ] ;
                            <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest>
                                    () ;
                            <http://research.ibm.com/ontologies/graph#referencedBy>
                                    <hk://b/f874a1aa-68c2-11ec-a469-7b1028dfc5e7>
                          ] ;
                  <http://research.ibm.com/ontologies/graph#referencedBy>
                          <hk://b/f874a1a8-68c2-11ec-a469-7b1028dfc5e7>
                ] .
```

However, in the latest version the serialization is producing a result in which the blanknodes are not being "suppressed":
```
<http://swat.cse.lehigh.edu/onto/univ-bench.owl#Chair>
        a       <http://www.w3.org/2002/07/owl#Class> ;
        <http://www.w3.org/2000/01/rdf-schema#label>
                "chair" ;
        <http://www.w3.org/2000/01/rdf-schema#subClassOf>
                <http://swat.cse.lehigh.edu/onto/univ-bench.owl#Professor> ;
        <http://research.ibm.com/ontologies/graph#isa>
                <http://research.ibm.com/ontologies/graph#node> ;
        <http://www.w3.org/2002/07/owl#intersectionOf>
                _:b1 .

_:b1    <http://www.w3.org/1999/02/22-rdf-syntax-ns#first>
                <http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person> ;
        <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest>
                _:b2 .
```

This is making some reasoning tasks fail, as the reasoner is not being able to infer the relationships based on the later form of serialization, which is likely failing to represent the blank node relationships correctly.

After a tedious investigation, I realized that the main reason for the blank nodes not being serialized as before, is the change we made to use the predicate `<http://research.ibm.com/ontologies/graph#references>` instead of `<http://research.ibm.com/ontologies/graph#referencedBy>` to serialize refnodes.

Since by default, the library always generates refnodes to allow creating relationships with blank nodes, the fact that when using `<http://research.ibm.com/ontologies/graph#references>` the blanknode becomes the object of the relationship causes the serialization to become messy. Therefore, my proposed solution is to use the `<http://research.ibm.com/ontologies/graph#referencedBy>` predicate only to serialize refnodes of blanknodes.

Using this fix the result of the serialization of blanknodes worked as previously and the queries that were retrieving incomplete results started retrieving all expected tuples.

I've also made some changes to avoid generating connectors for blanknodes.

Further testing is still necessary, nonetheless I intend to run them after this version passes the review and gets published, as it will make it easier to run tests using our automated pipeline.
