### PR TITLE
Refactoring refnode queries that use UNION to use OPTIONAL+FILTER in order to avoid agraph bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rdf2hk",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "This library converts RDF to Hyperknowledge Description",
   "main": "index.js",
   "author": "IBM Research",


### PR DESCRIPTION
Agraph fails to process the refnode queries with union, therefore I had to refactor some of them to use OPTIONAL combined with FILTER to produce the same output.

I've already tested with agraph and jena.