### PR TITLE
Refactoring one of the refnode queries to use UNION again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rdf2hk",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "This library converts RDF to Hyperknowledge Description",
   "main": "index.js",
   "author": "IBM Research",

--- a/sparqlfactory.js
+++ b/sparqlfactory.js
@@ -1198,16 +1198,14 @@ function appendUnionFilters(builder, andFilters, idVar = "s")
 					{
 						builder.addValues("r", constraintValue, true);
 						builder.append(`
-						OPTIONAL { 
-							BIND(${HKUris.REFERENCES_URI} as ?ref_predicate)
+						{ 
 							?s ${HKUris.REFERENCES_URI} ?r . 
 						}`);
+						builder.appendUnion();
 						builder.append(`
-						OPTIONAL { 
-							BIND(${HKUris.REFERENCED_BY_URI} as ?ref_predicate)
+						{ 
 							?r ${HKUris.REFERENCED_BY_URI} ?s. 
 						}`);
-						builder.append(`FILTER (bound(?ref_predicate))`);
 					}
 					else if(constraint.parent)
 					{


### PR DESCRIPTION
This specific query works with UNION in agraph and the version with option was retrieving unexpected results with agraph v7.2.0 (worked well with 6.6.0).

The refactored version works with all configurations.