### PR TITLE
Fixing removal of links involving refnodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rdf2hk",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rdf2hk",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "This library converts RDF to Hyperknowledge Description",
   "main": "index.js",
   "author": "IBM Research",

--- a/sparqlfactory.js
+++ b/sparqlfactory.js
@@ -670,7 +670,7 @@ function removeEntities (ids)
 
 	let builder = new SparqlBuilder();
 
-	builder.delete("GRAPH ?g {?s ?p ?o} . GRAPH ?g {?a ?b ?c} ");
+	builder.delete("GRAPH ?g {?s ?p ?o} . GRAPH ?g {?a ?b ?c} . GRAPH ?g_ref {?s ?p ?o} . ");
 
 	builder.where(() =>
 	{
@@ -729,8 +729,15 @@ function removeEntities (ids)
 		FILTER (bound(?ref_predicate_s) && bound(?ref_predicate_o))
 }
 ?p ?subject_role "s";
-		?object_role "o" .`);
-			builder.append(DEFAULT_GRAPH_PATTERN);
+   ?object_role "o" .
+{
+	${DEFAULT_GRAPH_PATTERN}
+}
+UNION
+{
+	GRAPH ?g_ref {?s ?p ?o}
+}`
+			);
 		});
 		
 	});


### PR DESCRIPTION
When removing links that involved refnodes, the dereferenced RDF triples were not being properly removed in all usage scenarios.