### PR TITLE
Solving Compatibility Issues with AllegroGraph

### DIFF
--- a/jsongraph.js
+++ b/jsongraph.js
@@ -139,7 +139,8 @@ JSONGraph.prototype.parseLiteral = function (literal)
 	const xsdBegin = literal.indexOf("^^<");
 	const xsdEnd = literal.lastIndexOf(">");
 	const literalHasXSD = xsdBegin > 0 && xsdEnd == literal.length - 1;
-	const literalHasCustomMetaProperty = !literalHasXSD && literal.indexOf(`"^^`) < literal.length - 1;
+	const metaPropertyBegin = literal.indexOf(`"^^`);
+	const literalHasCustomMetaProperty = !literalHasXSD && metaPropertyBegin > 0 && metaPropertyBegin < literal.length - 1;
 	// Ensure we have enough lookahead to identify triple-quoted strings
 	// literals with XSD or Custom MetaProperties should not be unescaped
 	if (literal.length >= 3 && !(literalHasXSD || literalHasCustomMetaProperty)) 

--- a/jsongraph.js
+++ b/jsongraph.js
@@ -81,7 +81,7 @@ JSONGraph.prototype.forEachStatement = function (callback)
 	{
 		let t = this.triples[i];
 		let object = t[2];
-		object = object.includes(`"`) ? this.parseLiteral(object) : object;
+		object = object && object.includes(`"`) ? this.parseLiteral(object) : object;
 		t[2] = object;
 		callback(t[0], t[1], object, t[3]);
 	}

--- a/jsongraph.js
+++ b/jsongraph.js
@@ -139,9 +139,10 @@ JSONGraph.prototype.parseLiteral = function (literal)
 	const xsdBegin = literal.indexOf("^^<");
 	const xsdEnd = literal.lastIndexOf(">");
 	const literalHasXSD = xsdBegin > 0 && xsdEnd == literal.length - 1;
+	const literalHasCustomMetaProperty = !literalHasXSD && literal.indexOf(`"^^`) < literal.length - 1;
 	// Ensure we have enough lookahead to identify triple-quoted strings
-	// literals with XSD should not be unescaped
-	if (literal.length >= 3 && !literalHasXSD) 
+	// literals with XSD or Custom MetaProperties should not be unescaped
+	if (literal.length >= 3 && !(literalHasXSD || literalHasCustomMetaProperty)) 
 	{
 		const literalStr = literalHasXSD ? literal.substring(0, xsdBegin) : literal;	
 

--- a/jsongraph.js
+++ b/jsongraph.js
@@ -172,23 +172,24 @@ JSONGraph.prototype.parseLiteral = function (literal)
 }
 
 // This method was based on the _unescape function of the N3Lexer.js file from https://github.com/rdfjs/N3.js
-JSONGraph.prototype.unescapeLiteral = function (literal) 
-{
+JSONGraph.prototype.unescapeLiteral = function (literal) {
 	let invalidEscaping = false;
-	
-	const unescapedLiteral = literal.replace(ESCAPE_SEQUENCE, (sequence, unicode4, unicode8, escapedChar) => 
+
+	let unescapedLiteral = literal;
+	while(unescapedLiteral.match(ESCAPE_SEQUENCE) !== null)
 	{
-		// 4-digit unicode character
-		if (typeof unicode4 === 'string') return String.fromCharCode(Number.parseInt(unicode4, 16)); // 8-digit unicode character
-		if (typeof unicode8 === 'string') 
-		{
-			let charCode = Number.parseInt(unicode8, 16);
-			return charCode <= 0xFFFF ? String.fromCharCode(Number.parseInt(unicode8, 16)) : String.fromCharCode(0xD800 + ((charCode -= 0x10000) >> 10), 0xDC00 + (charCode & 0x3FF));
-		} // fixed escape sequence
-		if (escapedChar in ESCAPE_REPLACEMENTS) return ESCAPE_REPLACEMENTS[escapedChar]; // invalid escape sequence
-		invalidEscaping = true;
-		return '';
-	});
+		unescapedLiteral = unescapedLiteral.replace(ESCAPE_SEQUENCE, (sequence, unicode4, unicode8, escapedChar) => {
+			// 4-digit unicode character
+			if (typeof unicode4 === 'string') return String.fromCharCode(Number.parseInt(unicode4, 16)); // 8-digit unicode character
+			if (typeof unicode8 === 'string') {
+				let charCode = Number.parseInt(unicode8, 16);
+				return charCode <= 0xFFFF ? String.fromCharCode(Number.parseInt(unicode8, 16)) : String.fromCharCode(0xD800 + ((charCode -= 0x10000) >> 10), 0xDC00 + (charCode & 0x3FF));
+			} // fixed escape sequence
+			if (escapedChar in ESCAPE_REPLACEMENTS) return ESCAPE_REPLACEMENTS[escapedChar]; // invalid escape sequence
+			invalidEscaping = true;
+			return '';
+		});
+	}
 	return invalidEscaping ? literal : unescapedLiteral;
 }
 

--- a/jsongraph.js
+++ b/jsongraph.js
@@ -49,8 +49,10 @@ JSONGraph.prototype.forEachStatement = function (callback)
 	for(let i = 0; i < this.triples.length; i++)
 	{
 		let t = this.triples[i];
-		
-		callback(t[0], t[1], t[2], t[3]);
+		let object = t[2];
+		object = object.includes(`"`) ? this.parseLiteral(object) : object;
+		t[2] = object;
+		callback(t[0], t[1], object, t[3]);
 	}
 }
 
@@ -74,6 +76,9 @@ JSONGraph.prototype.fromBGP = function (s = null, p = null, o = null, g = null)
 			}
 			else if(o === t[2])
 			{
+				let object = t[2];
+				object = object.includes(`"`) ? this.parseLiteral(object) : object;
+				t[2] = object;
 				out.push(t);
 			}
 			else if(g === t[3])
@@ -94,6 +99,68 @@ JSONGraph.prototype.fromBGP = function (s = null, p = null, o = null, g = null)
 JSONGraph.prototype.graphSize = function ()
 {
 	return this.statementCounter;	
+}
+
+JSONGraph.prototype.parseLiteral = function (literalStr) 
+{
+	// Ensure we have enough lookahead to identify triple-quoted strings
+	const quoteStr = `"`;
+	if (literalStr.length >= 3 && literalStr[0] == quoteStr && literalStr[literalStr.length - 1] == quoteStr) 
+	{
+		literalStr = literalStr.substring(1, literalStr.length - 1);
+		if (literalStr.includes(`\\"`)) return this.unescapeLiteral(literalStr);
+	}
+	return literalStr;
+}
+
+// This method was based on the _unescape function of the N3Lexer.js file from https://github.com/rdfjs/N3.js
+JSONGraph.prototype.unescapeLiteral = function (literal) 
+{
+	let invalidEscaping = false;
+	const escapeSequence = /\\u([a-fA-F0-9]{4})|\\U([a-fA-F0-9]{8})|\\([^])/g;
+	const escapeReplacements = {
+		'\\': '\\',
+		"'": "'",
+		'"': '"',
+		'n': '\n',
+		'r': '\r',
+		't': '\t',
+		'f': '\f',
+		'b': '\b',
+		'_': '_',
+		'~': '~',
+		'.': '.',
+		'-': '-',
+		'!': '!',
+		'$': '$',
+		'&': '&',
+		'(': '(',
+		')': ')',
+		'*': '*',
+		'+': '+',
+		',': ',',
+		';': ';',
+		'=': '=',
+		'/': '/',
+		'?': '?',
+		'#': '#',
+		'@': '@',
+		'%': '%'
+	};
+	const unescapedLiteral = literal.replace(escapeSequence, (sequence, unicode4, unicode8, escapedChar) => 
+	{
+		// 4-digit unicode character
+		if (typeof unicode4 === 'string') return String.fromCharCode(Number.parseInt(unicode4, 16)); // 8-digit unicode character
+		if (typeof unicode8 === 'string') 
+		{
+			let charCode = Number.parseInt(unicode8, 16);
+			return charCode <= 0xFFFF ? String.fromCharCode(Number.parseInt(unicode8, 16)) : String.fromCharCode(0xD800 + ((charCode -= 0x10000) >> 10), 0xDC00 + (charCode & 0x3FF));
+		} // fixed escape sequence
+		if (escapedChar in escapeReplacements) return escapeReplacements[escapedChar]; // invalid escape sequence
+		invalidEscaping = true;
+		return '';
+	});
+	return invalidEscaping ? literal : unescapedLiteral;
 }
 
 module.exports = JSONGraph;

--- a/jsongraph.js
+++ b/jsongraph.js
@@ -81,7 +81,7 @@ JSONGraph.prototype.forEachStatement = function (callback)
 	{
 		let t = this.triples[i];
 		let object = t[2];
-		object = object && object.includes(`"`) ? this.parseLiteral(object) : object;
+		object = object && object.startsWith(`"`) ? this.parseLiteral(object) : object;
 		t[2] = object;
 		callback(t[0], t[1], object, t[3]);
 	}
@@ -108,7 +108,7 @@ JSONGraph.prototype.fromBGP = function (s = null, p = null, o = null, g = null)
 			else if(o === t[2])
 			{
 				let object = t[2];
-				object = object.includes(`"`) ? this.parseLiteral(object) : object;
+				object = object.startsWith(`"`) ? this.parseLiteral(object) : object;
 				t[2] = object;
 				out.push(t);
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rdf2hk",
-  "version": "1.10.12",
+  "version": "2.0.0",
   "description": "This library converts RDF to Hyperknowledge Description",
   "main": "index.js",
   "author": "IBM Research",

--- a/sparqlfactory.js
+++ b/sparqlfactory.js
@@ -577,6 +577,15 @@ function updateTriples (changedEntities, changedParents)
 						{
 							builder.append(`GRAPH ${t[3]} { ${t[0]} ${t[1]} ${JSON.stringify(t[2])} } . `);
 						}
+						else if(t[2].match(/"/g) !== null && t[2].match(/"/g).length > 2)
+						{
+							const unescapedLiteralStrBegin = t[2].indexOf(`"`) + 1;
+							const unescapedLiteralStrEnd = t[2].lastIndexOf(`"`);
+							const unescapedLiteralStr = t[2].substring(unescapedLiteralStrBegin, unescapedLiteralStrEnd);
+							const escapedLiteralStr = JSON.stringify(unescapedLiteralStr);
+							const escapedLiteral = t[2].replace(`"${unescapedLiteralStr}"`, escapedLiteralStr);
+							builder.append(`GRAPH ${t[3]} { ${t[0]} ${t[1]} ${escapedLiteral} } . `);
+						}
 						else
 						{
 							builder.append(`GRAPH ${t[3]} { ${t[0]} ${t[1]} ${t[2]} } . `);

--- a/sparqlfactory.js
+++ b/sparqlfactory.js
@@ -577,7 +577,7 @@ function updateTriples (changedEntities, changedParents)
 						{
 							builder.append(`GRAPH ${t[3]} { ${t[0]} ${t[1]} ${JSON.stringify(t[2])} } . `);
 						}
-						else if(t[2].match(/"/g) !== null && t[2].match(/"/g).length > 2)
+						else if(t[2].match(/"/g) !== null && t[2].match(/"/g).length > 2 && t[2].indexOf(`"^^<`) == t[2].indexOf(`"^^`)  )
 						{
 							const unescapedLiteralStrBegin = t[2].indexOf(`"`) + 1;
 							const unescapedLiteralStrEnd = t[2].lastIndexOf(`"`);

--- a/utils.js
+++ b/utils.js
@@ -429,7 +429,7 @@ function getTypeIfNumberOrBoolean(value)
 {
     if(typeof value === "number")
     {
-		return Number.isInteger(value) ? xml.INTEGER_URI : xml.DOUBLE_URI;
+		return Number.isInteger(value) ? xml.INTEGER_URI : xml.DECIMAL_URI;
     }
 	else if(typeof value === "boolean")
 	{
@@ -454,11 +454,11 @@ function createLiteralObject(value, lang, type)
 			case 'number':
 				if (Number.isFinite(value)) 
 				{
-					type = Number.isInteger(value) ? xml.INTEGER_URI : xml.DOUBLE_URI;
+					type = Number.isInteger(value) ? xml.INTEGER_URI : xml.DECIMAL_URI;
 				}
 				else 
 				{
-					type = xml.DOUBLE_URI;
+					type = xml.DECIMAL_URI;
 					if (!Number.isNaN(value)) 
 					{
 						value = value > 0 ? 'INF' : '-INF';


### PR DESCRIPTION
## Changing default xsd type for non-integer numbers to decimal (from double)

Motivated by the recently detected differences between the number of decimal cases supported for double XSD in Jena Fuseki and AllegroGraph, as well as several external references that point towards the more general nature the decimal XSD, I propose we change the default serialization of non-integer numbers (frequently present in properties of an HKEntity) to decimal XSD.

External references:
- https://github.com/w3c/json-ld-syntax/issues/318
- https://stackoverflow.com/questions/26909331/what-are-the-limits-of-the-decimal-type-in-xml-schema-xsd
- https://www.ibm.com/docs/en/jfsm/1.1.2.1?topic=queries-xsd-data-types
- https://www.w3schools.com/xml/schema_dtypes_numeric.asp
- https://franz.com/agraph/support/documentation/current/datatypes.html
- https://stackoverflow.com/questions/17073781/allegrograph-xsd-float-literals

OBS: I'm considering this to be a major release as it introduces a **potentially** (but **not necessarily**) breaking change.

## Adding automatic unescaping of literals objects in JSONGraph

As detected in recent tests with Jena Fuseki and AllegroGraph, some literals with escaped double quotes were being retrieved unescaped in Jena's configuration and escaped in AllegroGraph's configuration. The main reason for this is that our TrigGraph implementation (based on [N3.js library](https://github.com/rdfjs/N3.js)) that automatically unescapes literals stored in objects (such as JSON stored within a literal) was being used when retrieving SPARQL query results from Jena (which were in `application/trig` format), while in AllegroGraph's configuration is was not. This occurred because AllegroGraph retrieved the results in ```application/json``` format, forcing the usage of our JSONGraph implementation, that does not perform automatic unescaping (since it is not based on [N3.js library](https://github.com/rdfjs/N3.js)), instead of the TrigGraph implementation.

As we could not find the list of supported SPARQL response mime types in [AllegroGraph's HTTP Reference](https://franz.com/agraph/support/documentation/current/http-reference.html#backend-get/post-catalogs-repositories-sparql) we tried using "application/trig", "application/n-quads", and "text/turtle" (which could be parsed with the TrigGraph) . For all of those, AllegroGraph retrieved an error response with [406 status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406) and an error message similar to the following:
```
No suitable response format available for row-cursor. Your request accepts: text/turtle. Supported formats are: application/json, application/processed-csv, application/sparql-results+json, application/sparql-results+json-rows, application/sparql-results+ttl, application/sparql-results+xml, application/sparql-results+xml-rows, application/x-ag-binary-rdf, application/x-direct-upis, application/x-lisp-structured-expression, text/csv, text/csv-rows, text/integer, text/simple-csv, text/tab-separated-values, text/tab-separated-values-rows, text/table.
```

We've also tried using the `application/sparql-results+ttl` mime type, which seemed to be similar to "text/turtle" (although it has not been explicitly mentioned [SPARQL Protocol Specification](https://w3c.github.io/rdf-tests/sparql11/data-sparql11/protocol/index.html)) and parse the results as a TrigGraph pretending that it was in "text/turtle" format. Unfortunately this did not work and we had to pursue a different solution.

Therefore, to maintain this behavior (of automatic unescaping) when using AllegroGraph, we reproduced part of the unescaping logic present in the [N3.js library](https://github.com/rdfjs/N3.js) (used by the TriGraph) within our JSONGraph implementation.

### Handling redundant escaping of quotes in AllegroGraph

During our tests, we also detected that some literals contained redundant escaping of double quotes and, to properly handle those cases, the `unescapeLiteral` method implemented in JSONGraph needed to be refactored to perform as many unescapes where necessary to produce a completely unescaped string. Nonetheless, this also required that we added an additional treatment in the `updateTriples` method the SPARQLFactory class, to properly escape those literals when generating `INSERT DATA` clauses of a SPARQL update query.